### PR TITLE
Add Housing, Deprioritize Steel

### DIFF
--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -286,7 +286,7 @@ Engine.prototype = {
             require = !housing.require ? housing.require : crafts.getResource(housing.require);
 
             if (!require || require.value / require.maxValue >= limits) {
-                housings.housing(housing.housing);
+                builds.build(housing.housing);
             }
         }
     },

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -144,8 +144,8 @@ var options = {
             {craft: 'wood', require: 'catnip'},
             {craft: 'beam', require: 'wood'},
             {craft: 'slab', require: 'minerals'},
-            {craft: 'steel', require: 'coal'},
-            {craft: 'plate', require: 'iron'}
+            {craft: 'plate', require: 'iron'},
+            {craft: 'steel', require: 'coal'}
         ],
         hunt: true,
         praise: true
@@ -286,7 +286,7 @@ Engine.prototype = {
             require = !housing.require ? housing.require : crafts.getResource(housing.require);
 
             if (!require || require.value / require.maxValue >= limits) {
-                builds.build(housing.housing);
+                housings.build(housing.housing);
             }
         }
     },

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -187,6 +187,7 @@ var message = function () {
 var Engine = function () {
     this.builds = new Builds();
     this.crafts = new Crafts();
+    this.housings = new Builds();
 };
 
 Engine.prototype = {

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -102,6 +102,7 @@ optionsElement.append(optionsTitleElement);
 optionsListElement.append(getToggle('engine', 'Freeze Scientists'));
 optionsListElement.append(getToggle('craft', 'Auto Craft'));
 optionsListElement.append(getToggle('build', 'Auto Build'));
+optionsListElement.append(getToggle('housing', 'Auto Housing'));
 optionsListElement.append(getToggle('hunt', 'Auto Hunt'));
 optionsListElement.append(getToggle('praise', 'Auto Praise'));
 
@@ -133,6 +134,11 @@ var options = {
             {build: 'workshop', require: 'minerals'},
             {build: 'unicornPasture', require: false}
         ],
+        housing: true,
+        housings: [
+            {housing: 'hut', require: 'wood'},
+            {housing: 'logHouse', require: 'minerals'}
+        ],
         craft: true,
         crafts: [
             {craft: 'wood', require: 'catnip'},
@@ -149,6 +155,7 @@ var options = {
     },
     limit: {
         build: 0.75,
+        housing: 0.85,
         craft: 0.95,
         hunt: 0.95,
         faith: 0.95
@@ -204,6 +211,7 @@ Engine.prototype = {
         if (options.auto.praise) this.praiseSun();
         if (options.auto.hunt) this.sendHunters();
         if (options.auto.build) this.startBuilds();
+        if (options.auto.housing) this.startHousings();
         if (options.auto.craft) this.startCrafts();
     },
     observeGameLog: function () {
@@ -264,6 +272,21 @@ Engine.prototype = {
 
             if (!require || require.value / require.maxValue >= limits) {
                 builds.build(build.build);
+            }
+        }
+    },
+    startHousings: function () {
+        var housings = this.housings;
+        var crafts = this.crafts;
+        var limits = options.limit.housing;
+        var housing, require;
+
+        for (i in options.auto.housings) {
+            housing = options.auto.housings[i];
+            require = !housing.require ? housing.require : crafts.getResource(housing.require);
+
+            if (!require || require.value / require.maxValue >= limits) {
+                housings.build(housing.housing);
             }
         }
     },

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -286,7 +286,7 @@ Engine.prototype = {
             require = !housing.require ? housing.require : crafts.getResource(housing.require);
 
             if (!require || require.value / require.maxValue >= limits) {
-                housings.build(housing.housing);
+                housings.housing(housing.housing);
             }
         }
     },


### PR DESCRIPTION
This would add the "Auto Housing" option to automatically build huts and log houses separately from other buildings, and at a slightly higher trigger point.

Also, triggers plates before steel to see if that gets a better plates vs. steel balance.