### PR TITLE
Don't let catnip get exhausted over winter.

### DIFF
--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -415,7 +415,16 @@ Crafts.prototype = {
         return game.resPool.get(name);
     },
     getValue: function (name) {
-        return this.getResource(name).value;
+        var value = this.getResource(name).value;
+        if (name == 'catnip') {
+            var depletion = game.getResourcePerTick(name, false, {
+                modifiers: {
+                    'catnip': 0.10 - game.calendar.getWeatherMod()
+                }}) * 202 * 5;
+            if (depletion < 0)
+                value += depletion;
+        }
+        return value;
     }
 };
 


### PR DESCRIPTION
This effectively removes the amount of catnip needed to survive a cold winter from consideration, so that the autobuild doesn't decide it needs a brand new catnip field on Autumn day 100 and kill off all the kittens.