### PR TITLE
kitten-scientists: add trading support

### DIFF
--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -372,7 +372,7 @@ TradeManager.prototype = {
             result = true;
 
             for (i in materials) {
-                var total = this.craftManager.getValueAvailable(i);
+                var value = this.craftManager.getValueAvailable(i);
 
                 if (value < materials[i] * amount) {
                     result = false;

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -356,12 +356,7 @@ TradeManager.prototype = {
         var yieldRes = 0;
         
         if (!button) return;
-        
-        // accumulate yield using internal function
-        for (i = 0; i < amount; i++) {
-            yieldRes += button.tradeInternal();
-        }
-        button.printYieldOutput(yieldRes);
+        button.tradeMultiple(amount);
 
         message('Kittens Craft: +' + name + ' x' + amount);
     },

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -355,6 +355,8 @@ TradeManager.prototype = {
         var button = this.getTradeButton(name);
         var yieldRes = 0;
         
+        if (!button) return;
+        
         // accumulate yield using internal function
         for (i = 0; i < amount; i++) {
             yieldRes += button.tradeInternal();

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -118,7 +118,7 @@ Engine.prototype = {
         if (options.toggle.crafting) this.startCrafts('craft', options.auto.craft);
         if (options.toggle.building) this.startBuilds('build', options.auto.build);
         if (options.toggle.housing) this.startBuilds('house', options.auto.house);
-        if (options.toggle.trading) this.startTrades('trade'), options.auto.trade);
+        if (options.toggle.trading) this.startTrades('trade', options.auto.trade);
     },
     observeGameLog: function () {
         $('#gameLog').find('input').click();

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -40,7 +40,7 @@ var options = {
             {name: 'parchment', require: false},
             {name: 'manuscript', require: 'culture'},
             {name: 'compendium', require: 'science'}
-        ]
+        ],
         trade: [
             {name: 'zebras', require: 'slab'}
         ]

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -183,7 +183,7 @@ Engine.prototype = {
         var manager = this.tradeManager;
         for (i in trades) {
             var trade = trades[i];
-            var require = manager.getResource(trade.require);
+            var require = manager.craftManager.getResource(trade.require);
             
             if (limit <= require.value / require.maxValue) {
                 manager.trade(trade.name, manager.getLowestTradeAmount(trade.name));

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -177,7 +177,7 @@ Engine.prototype = {
                 manager.craft(craft.name, manager.getLowestCraftAmount(craft.name));
             }
         }
-    }
+    },
     startTrades: function(type, trades) {
         var limit = options.limit[type];
         var manager = this.tradeManager;


### PR DESCRIPTION
This patch updates the kitten scientists to include support for automatic trading. Since I was able to locate trade buttons in the game API, it does not require switching to the trade tab to run. I also fixed up hunting so that parchment is a luxury good and honors a limit for furs.