### PR TITLE
Add automatic trading support

### DIFF
--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -152,9 +152,9 @@ Engine.prototype = {
 
         for (i in builds) {
             var build = builds[i];
-            var require = !build.require ? !build.require : craftManager.getResource(build.require);
+            var require = !build.require ? false : craftManager.getResource(build.require);
 
-            if (require === true || limit <= require.value / require.maxValue) {
+            if (require === false || limit <= require.value / require.maxValue) {
                 buildManager.build(build.name);
             }
         }

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -133,7 +133,7 @@ Engine.prototype = {
         }
     },
     sendHunters: function () {
-        var catpower = this.craftManager.getResource('manpower');
+        var catpower = this.craftManager.getResource('catpower');
         var workshop = game.workshop;
         var parchment = workshop.getCraft('parchment');
 
@@ -295,6 +295,9 @@ CraftManager.prototype = {
     getResource: function (name) {
         // adjust for spelling bug in core game logic
         if ('compendium' === name) name = 'compedium';
+
+        // adjust for displayed name
+        if ('catpower' === name) name = 'manpower';
 
         return game.resPool.get(name);
     },

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -108,9 +108,9 @@ Engine.prototype = {
         this.observeGameLog();
         if (options.toggle.praising) this.praiseSun();
         if (options.toggle.hunting) this.sendHunters();
-        if (options.toggle.crafting) this.startCrafts('craft', options.auto.craft);
         if (options.toggle.building) this.startBuilds('build', options.auto.build);
         if (options.toggle.housing) this.startBuilds('house', options.auto.house);
+        if (options.toggle.crafting) this.startCrafts('craft', options.auto.craft);
     },
     observeGameLog: function () {
         $('#gameLog').find('input').click();

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -161,14 +161,14 @@ Engine.prototype = {
     },
     startCrafts: function (type, crafts) {
         var limit = options.limit[type];
-        var manager = this.craftManager;
+        var craftManager = this.craftManager;
 
         for (i in crafts) {
             var craft = crafts[i];
-            var require = manager.getResource(craft.require);
+            var require = !craft.require ? false : craftManager.getResource(craft.require);
 
             if (limit <= require.value / require.maxValue) {
-                manager.craft(craft.name, manager.getLowestCraftAmount(craft.name));
+                craftManager.craft(craft.name, craftManager.getLowestCraftAmount(craft.name));
             }
         }
     }

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -22,7 +22,7 @@ var options = {
             {name: 'workshop', require: 'minerals'},
             {name: 'lumberMill', require: 'minerals'},
             {name: 'aqueduct', require: 'minerals'},
-            {name: 'unicornPasture', require: false},
+            {name: 'unicornPasture', require: 'unicorns'},
             {name: 'tradepost', require: 'gold'}
         ],
         craft: [

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -38,6 +38,7 @@ var options = {
             {name: 'mansion', require: 'titanium'}
         ],
         luxury: [
+            {name: 'parchment', require: 'furs'},
             {name: 'manuscript', require: 'culture'},
             {name: 'compendium', require: 'science'}
         ]
@@ -51,6 +52,7 @@ var options = {
         faith: 0.99
     },
     stock: {
+        furs: 1000,
         compendium: 500,
         manuscript: 500,
         parchment: 500
@@ -136,11 +138,7 @@ Engine.prototype = {
         var parchment = workshop.getCraft('parchment');
 
         if (catpower.value / catpower.maxValue > options.limit.hunt) {
-            if (parchment.unlocked) {
-                game.craftAll(parchment.name);
-                message('Auto Hunt: crafted all parchments');
-            }
-
+            // Generate luxury goods first, before sending hunters
             if (options.toggle.luxury) this.startCrafts('luxury', options.auto.luxury);
 
             message('Kittens Hunt: Hunters deployed!');

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -15,13 +15,13 @@ var options = {
         build: [
             {name: 'field', require: 'catnip'},
             {name: 'pasture', require: 'catnip'},
+            {name: 'mine', require: 'wood'},
             {name: 'library', require: 'wood'},
             {name: 'academy', require: 'wood'},
-            {name: 'mine', require: 'wood'},
             {name: 'barn', require: 'wood'},
-            {name: 'aqueduct', require: 'minerals'},
-            {name: 'lumberMill', require: 'minerals'},
             {name: 'workshop', require: 'minerals'},
+            {name: 'lumberMill', require: 'minerals'},
+            {name: 'aqueduct', require: 'minerals'},
             {name: 'unicornPasture', require: false},
             {name: 'tradepost', require: 'gold'}
         ],

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -22,7 +22,8 @@ var options = {
             {name: 'aqueduct', require: 'minerals'},
             {name: 'lumberMill', require: 'minerals'},
             {name: 'workshop', require: 'minerals'},
-            {name: 'unicornPasture', require: false}
+            {name: 'unicornPasture', require: false},
+            {name: 'tradepost', require: 'gold'}
         ],
         craft: [
             {name: 'wood', require: 'catnip'},


### PR DESCRIPTION
This series adds automatic trading support for zebras, and also includes some fixes from trini/cbc-kitten-scientists

The 3 patches not marked local from trini's pull are included as the first 3, with updated descriptions. I figured that was easier than trying to extract the local fixes out of that branch.

The patch series starts of with some minor changes I discovered while working, and then ends with the implementation of TradeManager and startTrades function. I separated everything out into patches as best as I could.

I believe I fixed all the major issues with use, though setting the correct defaults is something I am not certain on.

Generally, I solved the problem of multiple races by giving each race an "extra" amount to reduce total use per race. So the total amount of resource used will be determined via the standard limit/amount setting. Then, we calculate a total max number of trades we can do. This value is then reduced by the per-race percentage, and that is fed into the calculation for minimum trades. In this way, we can reduce each race so that we could say:

zebras gets 50% of the trade allotment, and sharks get 50% of the trade allotment. It should result in about 50% split between the two races. I have chosen to set trading to even lower and only for zebras in order to prevent trading from hogging all of the catpower necessary for hunting.

The series also includes some fixes to parchment handling to reduce code complexity and remove special case of parchment. This enables setting a limit for fur. It does have the odd effect that we only use half of our furs each time, but I think that's generally fine. (Users should be able to customize the default settings via a pull/fork)