### PR TITLE
buildManager: use internal buttons instead of loaded page

### DIFF
--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -187,12 +187,9 @@ BuildManager.prototype = {
     build: function (name) {
         if (!this.isBuildable(name)) return;
 
-        var label = this.getBuild(name).label;
-        var button = $(".nosel:not('.disabled'):contains('" + label + "')");
+        var button = this.getBuildButton(name);
 
-        if (button.length === 0) return;
-
-        button.click();
+        button.onClick();
         message('Kittens Build: +1 ' + label);
     },
     isBuildable: function (name) {
@@ -215,6 +212,17 @@ BuildManager.prototype = {
     },
     getBuild: function (name) {
         return game.bld.getBuilding(name);
+    },
+    getBuildButton: function (name) {
+        if (game.bonfireTab.buttons === [])
+            game.bonfireTab.render()
+
+        for (i in game.bonfireTab.buttons) {
+            var btn = game.bonfireTab.buttons[i];
+            if (btn.name.toLowerCase() == name.toLowerCase()) return btn;
+        }
+
+        return null;
     },
     getPrices: function (name) {
         return game.bld.getPrices(name);


### PR DESCRIPTION
This enables building even when it's not the bonfireTab loaded. Do this by
ensuring we render() the bonfireTab first time we need it. Then, we can
just search the buttons list and locate the item and use the onClick()
function. This is much cleaner than having to be loaded on the bonfire tab
directly. This is similar to how automated trading is implemented.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>