### PR TITLE
Add option to automatically hold festivals

### DIFF
--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -128,18 +128,11 @@ Engine.prototype = {
         $('#gameLog').find('input').click();
     },
     praiseSun: function () {
-        var currentTab = game.activeTabId;
         var faith = this.craftManager.getResource('faith');
 
         if (faith.value / faith.maxValue >= options.limit.faith) {
-            game.activeTabId = 'Religion';
-            game.render();
-
             message('The sun has been praised!');
-            $(".nosel:contains('Praise the sun!')").click();
-
-            game.activeTabId = currentTab;
-            game.render();
+            game.religion.praise();
         }
     },
     sendHunters: function () {

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -544,8 +544,11 @@ var getToggle = function (name, text) {
     var toggle = $('<input/>', {
         id: 'toggle-' + name,
         type: 'checkbox',
-        checked: 'checked'
     });
+
+    if ( options.toggle[name] ) {
+      toggle.prop('checked', 'checked');
+    }
 
     return li.append(toggle, label);
 };
@@ -590,13 +593,11 @@ toggleEngine.trigger('change');
 // Add toggles for options
 // =======================
 
-var autoOptions = ['building', 'crafting', 'housing', 'hunting', 'luxury', 'praising', 'trading'];
-
 var ucfirst = function (string) {
     return string.charAt(0).toUpperCase() + string.slice(1);
 };
 
-$.each(autoOptions, function (event, option) {
+$.each(Object.keys(options.toggle), function (event, option) {
     var toggle = $('#toggle-' + option);
 
     toggle.on('change', function () {
@@ -605,7 +606,7 @@ $.each(autoOptions, function (event, option) {
             message('Enabled Auto ' + ucfirst(option));
         } else {
             options.toggle[option] = false;
-            message('Disable Auto ' + ucfirst(option));
+            message('Disabled Auto ' + ucfirst(option));
         }
     });
 });

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -138,11 +138,12 @@ Engine.prototype = {
         }
     },
     holdFestival: function () {
+        if (!game.science.get('drama').researched) return;
         var festivalDays = game.calendar.festivalDays;
 
         if (festivalDays === 0) {
             message('A festival has been held!');
-            game.villageTab.holdFestival();
+            game.villageTab.festivalBtn.onClick();
         }
     },
     sendHunters: function () {

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -130,14 +130,17 @@ Engine.prototype = {
         $('#gameLog').find('input').click();
     },
     praiseSun: function () {
+        game.religionTab.render();
+        if (!game.religionTab.praiseBtn.enabled) return;
         var faith = this.craftManager.getResource('faith');
 
         if (faith.value / faith.maxValue >= options.limit.faith) {
             message('The sun has been praised!');
-            game.religion.praise();
+            game.religionTab.praiseBtn.onClick();
         }
     },
     holdFestival: function () {
+        game.villageTab.render();
         if (!game.science.get('drama').researched) return;
         var festivalDays = game.calendar.festivalDays;
 

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -71,7 +71,8 @@ var options = {
         hunting: true,
         luxury: true,
         praising: true,
-        trading: true
+        trading: true,
+        festival: false
     }
 };
 
@@ -118,6 +119,7 @@ Engine.prototype = {
     iterate: function () {
         this.observeGameLog();
         if (options.toggle.praising) this.praiseSun();
+        if (options.toggle.festival) this.holdFestival();
         if (options.toggle.trading) this.startTrades('trade', options.auto.trade);
         if (options.toggle.hunting) this.sendHunters();
         if (options.toggle.building) this.startBuilds('build', options.auto.build);
@@ -133,6 +135,14 @@ Engine.prototype = {
         if (faith.value / faith.maxValue >= options.limit.faith) {
             message('The sun has been praised!');
             game.religion.praise();
+        }
+    },
+    holdFestival: function () {
+        var festivalDays = game.calendar.festivalDays;
+
+        if (festivalDays === 0) {
+            message('A festival has been held!');
+            game.villageTab.holdFestival();
         }
     },
     sendHunters: function () {
@@ -570,6 +580,7 @@ optionsListElement.append(getToggle('praising', 'Faith'));
 optionsListElement.append(getToggle('hunting', 'Hunting'));
 optionsListElement.append(getToggle('luxury', 'Luxury'));
 optionsListElement.append(getToggle('trading', 'Trading'));
+optionsListElement.append(getToggle('festival', 'Festival'));
 
 // add the options above the game log
 right.prepend(optionsElement.append(optionsListElement));

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -130,7 +130,7 @@ Engine.prototype = {
         $('#gameLog').find('input').click();
     },
     praiseSun: function () {
-        game.religionTab.render();
+        if (!game.religionTab.praiseBtn) game.religionTab.render();
         if (!game.religionTab.praiseBtn.enabled) return;
         var faith = this.craftManager.getResource('faith');
 
@@ -140,7 +140,7 @@ Engine.prototype = {
         }
     },
     holdFestival: function () {
-        game.villageTab.render();
+        if (!game.villageTab.festivalBtn) game.villageTab.render();
         if (!game.science.get('drama').researched) return;
         var festivalDays = game.calendar.festivalDays;
 


### PR DESCRIPTION
There are a few other small side effects to this PR, most notably that the engine is no longer enabled automatically when Kitten Scientists is loaded; the user must toggle it on.