### PR TITLE
Only call .render() if we're not already on the Bonfire tab.

### DIFF
--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -224,7 +224,9 @@ var BuildManager = function () {
 BuildManager.prototype = {
     craftManager: undefined,
     build: function (name) {
-        this.getTab('Bonfire').render();
+        if (game.activeTabId !== 'Bonfire') {
+            this.getTab('Bonfire').render();
+        }
         if (!this.isBuildable(name)) return;
 
         var button = this.getBuildButton(name);


### PR DESCRIPTION
Calling .render() on the currently active tab interferes with the normal re-rendering process.