### PR TITLE
kitten-scientists: stock some steel

### DIFF
--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -59,6 +59,7 @@ var options = {
         trade: 0.95
     },
     stock: {
+        steel: 1000,
         furs: 1000,
         compendium: 500,
         manuscript: 500,


### PR DESCRIPTION
To prevent alloy production from completely draining the steel reserves,
add a limit so that we won't use up the steel. We probably will need some more advanced way to configure this in the future.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>