### PR TITLE
canCraft: Take stock into account when checking amount of a resource

### DIFF
--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -322,7 +322,12 @@ CraftManager.prototype = {
 
             for (i in craft.prices) {
                 var price = craft.prices[i];
-                var value = this.getValueAvailable(price.name);
+                var name = price.name;
+                var value = this.getValueAvailable(name);
+                // Adjust name back to correct spelling
+                if ('compedium' === name) name = 'compendium';
+                // Adjust for stock
+                value -= options.stock[name] || 0;
 
                 if (value < price.val * amount) {
                     result = false;


### PR DESCRIPTION
We need to remove the stock amount from the amount of an item we have.
Without this for example we'll happily craft away compendiums into
blueprints.  We also need to adjust the name here given how we list it
in the stock array.