### PR TITLE
Prevent over trading, and allow controlling which seasons to trade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## History
 
+### 2015.04.30 - Version 1.2.1
+
+- Added mint to the building list. (thanks [lightrider44](https://www.reddit.com/user/lightrider44))
+- Removed trading cap temporarily. This will need re-enabled with better cap measures.
+- Added the remaining trade possibilities.
+
 ### 2015.04.30 - Version 1.2.0
 
 - Added granular controls for build orders. #8 #12 #21

--- a/README.md
+++ b/README.md
@@ -95,7 +95,14 @@ Builds the following buildings when required resource is at 75% capacity:
 
 Trades with the following races when gold is at 90% and the maximum resource is not met. Ex: zebras will trade when gold is at 90% and titanium is below 99% to prevent over trading.
 
-    zebras: (summer) enabled true
+    zebras: (summer)    enabled true
+    lizards: (summer)   enabled: false
+    sharks: (winter)    enabled: false
+    griffins: (autumn)  enabled: false
+    nagas: (spring)     enabled: false
+    spiders: (autumn)   enabled: false
+    dragons: (all)      enabled: false
+    leviathans: (all)   enabled: false
 
 #### Cat Power
 

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -658,12 +658,15 @@ var getToggle = function (toggleName, text) {
 
         var list = $('<ul/>', {
             id: 'toggle-options-list-' + toggleName,
-            css: {display: 'none', paddingLeft: '20px', width: '80%'}
+            css: {display: 'none', paddingLeft: '20px'}
         });
 
         // fill out list with toggle items
         for (var itemName in auto.items) {
-            list.append(getOption(itemName, auto.items[itemName]));
+            if (toggleName === 'trade')
+                list.append(getTradeToggle(itemName, auto.items[itemName]));
+            else
+                list.append(getOption(itemName, auto.items[itemName]));
         }
 
         button.on('click', function () {
@@ -672,6 +675,83 @@ var getToggle = function (toggleName, text) {
 
         element.append(button, list);
     }
+
+    return element;
+};
+
+var getTradeToggle = function (name, option) {
+    var element = $('<li/>');
+
+    var label = $('<label/>', {
+        'for': 'toggle-' + name,
+        text: ucfirst(name)
+    });
+
+    var input = $('<input/>', {
+        id: 'toggle-' + name,
+        type: 'checkbox'
+    });
+
+    if (option.enabled) {
+        input.prop('checked', 'checked');
+    }
+
+    element.append(input, label);
+
+    var button = $('<div/>', {
+        id: 'toggle-seasons-' + name,
+        text: 'toggle seasons',
+        css: {cursor: 'pointer', display: 'inline-block', float: 'right', paddingRight: '5px'}
+    });
+
+    var list = $('<ul/>', {
+        id: 'toggle-seasons-list-' + name,
+        css: {display: 'none', paddingLeft: '20px'}
+    });
+
+    // fill out the list with seasons
+    list.append(getSeason(name, 'spring', option));
+    list.append(getSeason(name, 'summer', option));
+    list.append(getSeason(name, 'autunn', option));
+    list.append(getSeason(name, 'winter', option));
+
+    button.on('click', function () {
+        list.toggle();
+    });
+
+    element.append(button, list);
+
+    return element;
+};
+
+var getSeason = function (name, season, option) {
+    var element = $('<li/>');
+
+    var label = $('<label/>', {
+        'for': 'toggle-' + name + '-' + season,
+        text: ucfirst(season)
+    });
+
+    var input = $('<input/>', {
+        id: 'toggle-' + name + '-' + season,
+        type: 'checkbox'
+    });
+
+    if (option[season]) {
+        input.prop('checked', 'checked');
+    }
+
+    input.on('change', function () {
+        if (input.is(':checked')) {
+            options.auto.trade.items[name][season] = true;
+            message('Enabled trading with ' + ucfirst(name) + ' in the ' + ucfirst(season));
+        } else {
+            option[season] = false;
+            message('Disabled trading ' + ucfirst(name) + ' in the ' + ucfirst(season));
+        }
+    });
+
+    element.append(input, label);
 
     return element;
 };

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -2,7 +2,7 @@
 // Begin Kitten Scientist's Automation Engine
 // ==========================================
 
-var version = 'Kitten Scientists version 1.2.0';
+var version = 'Kitten Scientists version 1.2.1';
 var address = '1AQ1AC9W5CEAPgG5739XGXC5vXqyafhoLp';
 var game = gamePage;
 
@@ -59,6 +59,7 @@ var options = {
                 tradepost: {require: 'gold', enabled: true},
                 chapel: {require: 'minerals', enabled: true},
                 temple: {require: 'gold', enabled: true},
+                mint: {require: false, enabled: true},
                 unicornPasture: {require: false, enabled: true},
                 ziggurat: {require: false, enabled: true},
                 chronosphere: {require: 'unobtanium', enabled: true}
@@ -87,7 +88,14 @@ var options = {
         // @TODO: enable other races for trading
         trade: {
             enabled: true, trigger: 0.90, items: {
-                zebras: {trigger: 0.95, max: 'titanium', require: false, season: 'summer', enabled: true}
+                zebras: {trigger: 0.95, max: 'titanium', require: false, season: 'summer', enabled: true},
+                lizards: {trigger: 0.95, max: false, require: 'minerals', season: 'summer', enabled: false},
+                sharks: {trigger: 0.95, max: false, require: 'iron', season: 'winter', enabled: false},
+                griffins: {trigger: 0.95, max: false, require: 'wood', season: 'autumn', enabled: false},
+                nagas: {trigger: 0.95, max: false, require: false, season: 'spring', enabled: false},
+                spiders: {trigger: 0.95, max: false, require: false, season: 'autumn', enabled: false},
+                dragons: {trigger: 0.95, max: false, require: 'uranium', season: false, enabled: false},
+                leviathans: {trigger: 0.95, max: false, require: 'unobtainium ', season: false, enabled: false}
             }
         }
     }
@@ -245,7 +253,7 @@ Engine.prototype = {
             // oh dear, this case is complicated ...
             if ((trigger <= gold.value / gold.maxValue)
                 && (!trade.season || trade.season === season)
-                && (!max || 1 !== max.value / max.maxValue)
+                //&& (!max || 1 !== max.value / max.maxValue) // trading max cap controls need to consider all resources instead of one
                 && (!require || requireTrigger <= require.value / require.maxValue)) {
                 tradeManager.trade(name, tradeManager.getLowestTradeAmount(name));
             }

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -673,6 +673,7 @@ optionsListElement.append(getToggle('festival', 'Festival'));
 // add donation address to bottom of list
 var donate = $('<li/>').append($('<a/>', {
     href: 'bitcoin:' + address + '?amount=0.005&label=Kittens Donation',
+    target: '_blank',
     text: address
 })).prepend($('<img/>', {
     css: {height: '15px', width: '15px', padding: '3px 4px 0 4px', verticalAlign: 'bottom'},

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -85,17 +85,16 @@ var options = {
                 megalith: {require: false, stock: 0, type: 'craft', enabled: false}
             }
         },
-        // @TODO: enable other races for trading
         trade: {
-            enabled: true, trigger: 0.90, items: {
-                zebras: {trigger: 0.95, max: 'titanium', require: false, season: 'summer', enabled: true},
-                lizards: {trigger: 0.95, max: false, require: 'minerals', season: 'summer', enabled: false},
-                sharks: {trigger: 0.95, max: false, require: 'iron', season: 'winter', enabled: false},
-                griffins: {trigger: 0.95, max: false, require: 'wood', season: 'autumn', enabled: false},
-                nagas: {trigger: 0.95, max: false, require: false, season: 'spring', enabled: false},
-                spiders: {trigger: 0.95, max: false, require: false, season: 'autumn', enabled: false},
-                dragons: {trigger: 0.95, max: false, require: 'uranium', season: false, enabled: false},
-                leviathans: {trigger: 0.95, max: false, require: 'unobtainium ', season: false, enabled: false}
+            enabled: true, trigger: 0.85, items: {
+                dragons: {trigger: 0.99, require: 'titanium', summer: true, autumn: true, winter: false, spring: true, enabled: false},
+                zebras: {trigger: 0.99, require: false, summer: true, autumn: false, winter: false, spring: false, enabled: true},
+                lizards: {trigger: 0.95, require: 'minerals', summer: true, autumn: false, winter: false, spring: false, enabled: false},
+                sharks: {trigger: 0.95, require: 'iron', summer: false, autumn: false, winter: true, spring: false, enabled: false},
+                griffins: {trigger: 0.99, require: 'wood', summer: true, autumn: false, winter: false, spring: false, enabled: false},
+                nagas: {trigger: 0.95, require: false, summer: false, autumn: false, winter: false, spring: true, enabled: false},
+                spiders: {trigger: 0.95, require: false, summer: false, autumn: true, winter: false, spring: true, enabled: false},
+                leviathans: {trigger: 0.99, require: 'unobtainium', summer: true, autumn: true, winter: true, spring: true, enabled: false},
             }
         }
     }
@@ -239,22 +238,26 @@ Engine.prototype = {
         var craftManager = this.craftManager;
         var tradeManager = this.tradeManager;
         var trades = options.auto.trade.items;
-        var trigger = options.auto.trade.trigger;
+        var gold = craftManager.getResource('gold');
+        var power = craftManager.getResource('catpower');
+
+        // Only trade if we have enough gold and catpower. Check once at start so that we don't starve multiple races
+        if (options.auto.trade.trigger >= gold.value / gold.maxValue) return;
+        if (options.auto.trade.trigger >= power.value / power.maxValue) return;
 
         for (var name in trades) {
             var trade = trades[name];
-
-            var gold = craftManager.getResource('gold');
-            var max = !trade.max ? false : craftManager.getResource(trade.max);
-            var require = !trade.require ? false : craftManager.getResource(trade.require);
-            var requireTrigger = trade.trigger;
             var season = game.calendar.getCurSeason().name;
 
-            // oh dear, this case is complicated ...
-            if ((trigger <= gold.value / gold.maxValue)
-                && (!trade.season || trade.season === season)
-                //&& (!max || 1 !== max.value / max.maxValue) // trading max cap controls need to consider all resources instead of one
-                && (!require || requireTrigger <= require.value / require.maxValue)) {
+            // Only check if we are in season and enabled
+            if (!trade.enabled) continue;
+            if (!trade[season]) continue;
+
+            var require = !trade.require ? false : craftManager.getResource(trade.require);
+            var requireTrigger = trade.trigger;
+
+            // If we have enough to trigger the check, then attempt to trade
+            if (!require || requireTrigger <= require.value / require.maxValue) {
                 tradeManager.trade(name, tradeManager.getLowestTradeAmount(name));
             }
         }
@@ -433,7 +436,6 @@ TradeManager.prototype = {
     craftManager: undefined,
     manager: undefined,
     trade: function (name, amount) {
-        amount = Math.floor(amount);
 
         if (!name || 1 > amount) return;
 
@@ -449,17 +451,60 @@ TradeManager.prototype = {
         message('Trade: ' + amount + 'x ' + race.title);
     },
     getLowestTradeAmount: function (name) {
-        var amount = 0;
+        var amount = -1;
+        var highestCapacity = undefined;
         var consume = options.consume;
         var materials = this.getMaterials(name);
+        var race = this.getRace(name);
 
         for (var i in materials) {
             var total = this.craftManager.getValueAvailable(i) * consume / materials[i];
 
-            amount = (0 === amount || total < amount) ? total : amount;
+            amount = (-1 === amount || total < amount) ? total : amount;
         }
 
-        return amount;
+        // Loop through the items obtained by the race, and determine
+        // which good has the most space left. Once we've determined this,
+        // reduce the amount by this capacity. This ensures that we continue to trade
+        // as long as at least one resource has capacity, and we never over-trade.
+        for (var s in race.sells) {
+            var item = race.sells[s];
+            var resource = this.craftManager.getResource(item.name);
+            var max = 0;
+
+            // No need to process resources that don't cap
+            if (!resource.maxValue) continue;
+
+            // Zebras special cased titanium taken directly from game code
+            if (race.name == "zebras" && item.name == "titanium") {
+                var val = 1.5 + (1.5 * game.resPool.get("ship").value / 100 * 2);
+                max = Math.ceil(val);
+            } else {
+                var sratio = item.seasons[game.calendar.getCurSeason().name];
+                var tratio = self.game.bld.getEffect("tradeRatio");
+                var val = item.value + item.value * tratio;
+
+                max = val * sratio * (1 + item.delta/2);
+            }
+
+            capacity = (resource.maxValue - resource.value) / max;
+
+            highestCapacity = (capacity < highestCapacity) ? highestCapacity : capacity;
+        }
+
+        // We must take the ceiling of capacity so that we will trade as long
+        // as there is any room, even if it doesn't have exact space. Otherwise
+        // we seem to starve trading altogether.
+        highestCapacity = Math.ceil(highestCapacity);
+
+        // Now that we know the most we *should* trade for, check to ensure that
+        // we trade for our max cost, or our max capacity, whichever is lower.
+        // This helps us prevent trading for resources we can't store. Note that we
+        // essentially ignore blueprints here. In addition, if highestCapacity was never set,
+        // then we just 
+        amount = (highestCapacity < amount) ? highestCapacity : amount;
+
+        return Math.floor(amount);
     },
     getMaterials: function (name) {
         var materials = {catpower: 50, gold: 15};


### PR DESCRIPTION
This patch series intends to fix up trading and should resolve some following issues and new features

a) trading would greedily trade with the first race only. That is, we would trade with the first race, and then re-check gold again for the second race and might stop if we got below our gold trigger percentage. This is bad, because we need to ensure multiple races all have a chance to trade. In my way, the first race has gold/catpower priority, and the second race will use up what it can if any is left. This is not really ideal, but I haven't figured out a masterful solution for it. At least this way we don't recheck if gold is actually *at* the cap each time.

b) trade only as much as we can store. Takes into account the maximum amount that we can receive for clicking trade once, and then calculates a capacity for each resource. It opts to allow trading as long as at least *one* resource has capacity to store more (excepting any resources which do not stock up like blueprints.) There is some rather funky code involved for calculating Zebra's titanium. This was taken directly from the base game code. I don't want to remove it because I want our calculations to be accurate.

c) enable user control for per-season trading. This is easier with the season refactor done in the first patch, and hopefully it's not too hacked in. It definitely could use a bit more TLC, but I can't think of a better way at this time of night.

The end result is a bit more control over trading. I added a couple races (disabled by default) that the user can configure. We could theoretically add every race now, but I didn't think most of the others are all that useful. I could be wrong though.

Hopefully this patch series is useful and acceptable.