### PR TITLE
crafting: add maximum resource check and per-season for uncapped reso…

### DIFF
--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -67,22 +67,22 @@ var options = {
         },
         craft: {
             enabled: true, trigger: 0.95, items: {
-                wood: {require: 'catnip', stock: 0, type: 'craft', enabled: true},
-                beam: {require: 'wood', stock: 0, type: 'craft', enabled: true},
-                slab: {require: 'minerals', stock: 0, type: 'craft', enabled: true},
-                steel: {require: 'coal', stock: 0, type: 'craft', enabled: true},
-                plate: {require: 'iron', stock: 0, type: 'craft', enabled: true},
-                alloy: {require: 'titanium', stock: 0, type: 'craft', enabled: false},
-                concrete: {require: false, stock: 0, type: 'craft', enabled: false},
-                gear: {require: false, stock: 0, type: 'craft', enabled: false},
-                scaffold: {require: false, stock: 0, type: 'craft', enabled: false},
-                ship: {require: false, stock: 0, type: 'craft', enabled: false},
-                tanker: {require: false, stock: 0, type: 'craft', enabled: false},
-                parchment: {require: false, stock: 0, type: 'luxury', enabled: true},
-                manuscript: {require: 'culture', stock: 0, type: 'luxury', enabled: true},
-                compendium: {require: 'science', stock: 0, type: 'luxury', enabled: true},
-                blueprint: {require: false, stock: 0, type: 'luxury', enabled: false},
-                megalith: {require: false, stock: 0, type: 'craft', enabled: false}
+                wood: {require: 'catnip', stock: 0, max: 0, type: 'craft', enabled: true},
+                beam: {require: 'wood', stock: 0, max: 0, type: 'craft', enabled: true},
+                slab: {require: 'minerals', stock: 0, max: 0, type: 'craft', enabled: true},
+                steel: {require: 'coal', stock: 0, max: 0, type: 'craft', enabled: true},
+                plate: {require: 'iron', stock: 0, max: 0, type: 'craft', enabled: true},
+                alloy: {require: 'titanium', stock: 0, max: 0, type: 'craft', enabled: false},
+                concrete: {require: false, stock: 0, max: 0, type: 'craft', enabled: false},
+                gear: {require: false, stock: 0, max: 0, type: 'craft', enabled: false},
+                scaffold: {require: false, stock: 0, max: 0, type: 'craft', enabled: false},
+                ship: {require: false, stock: 0, max: 0, type: 'craft', enabled: false},
+                tanker: {require: false, stock: 0, max: 0, type: 'craft', enabled: false},
+                parchment: {require: false, stock: 0, max: 0, type: 'luxury', enabled: true},
+                manuscript: {require: 'culture', stock: 0, max: 0, type: 'luxury', enabled: true},
+                compendium: {require: 'science', stock: 0, max: 0, type: 'luxury', enabled: true},
+                blueprint: {require: false, stock: 0, max: 0, type: 'luxury', enabled: false},
+                megalith: {require: false, stock: 0, max: 0, type: 'craft', enabled: false}
             }
         },
         // @TODO: enable other races for trading
@@ -194,10 +194,28 @@ Engine.prototype = {
 
         for (var name in crafts) {
             var craft = crafts[name];
+            var current = !craft.nax ? false : manager.getResource(name);
             var require = !craft.require ? false : manager.getResource(craft.require);
+            var season = game.calendar.getCurSeason().name;
 
-            if (craft.type === type && (!require || trigger <= require.value / require.maxValue)) {
+            // Only craft matching types
+            if (craft.type !== type) continue;
+
+            // Ensure that we have not reached our cap
+            if (current && current.value > craft.max) continue;
+
+            // If the required item has no maximum value, only craft this item
+            // once per season. This enables us to craft various goods which
+            // otherwise would starve us of resources. Possibly seasons don't
+            // last long enough, so further testing is required.
+            if ((require.maxValue === 0) || craft.lastSeason === season) continue;
+
+            // Craft the resource if we meet the trigger requirement
+            if (!require || trigger <= require.value / require.maxValue) {
                 manager.craft(name, manager.getLowestCraftAmount(name));
+
+                // Store the season for future reference
+                craft.lastSeason = season;
             }
         }
     },


### PR DESCRIPTION
…urces

Per the discussion on one of the suggestion threads, add support for two
methods of reducing crafting overhead.

a) add a max value for each resource. Eventually need some interface to
configure this. For now users can easily hack in using the console, and
insert "options.auto.crafts.items['xyz'].stock or max to change these
settings.

b) for items which require something that has no maximum value, only allow
trading once per season. There is a slight chance they will race if it
ends up a whole season comes back around before we try again. But in this
case, I don't think its that big a deal.

These changes should enable activation of more resource types without as
much hogging for the resources that are uncapped. Ie: we should end up
procuding less alloy, and without hogging all of the steel.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>