### PR TITLE
crafting: fix case when stock is greater than current value

### DIFF
--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -461,7 +461,7 @@ CraftManager.prototype = {
             if (resPerTick < 0) stock -= resPerTick * 202 * 5;
         }
 
-        return value - stock;
+        return Math.max(value - stock, 0);
     }
 };
 


### PR DESCRIPTION
We should ensure that stock checks work properly if the current value is
below the stock.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>