### PR TITLE
options: fix stocks mis-use of incorrect variable name

### DIFF
--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -882,7 +882,7 @@ var getStockOptions = function () {
         allstocks.append(getAvailableStockOptions());
     });
 
-    list.append(add, delempty, allstocks);
+    list.append(add, clearunused, allstocks);
 
     // Add all the default stocks
     for (var name in options.auto.stock) {


### PR DESCRIPTION
During a refactor, I renamed delempty to clearunused and forgot one
location. Fix this up so the options will get displayed.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>