### PR TITLE
trading: fix trade options for races

### DIFF
--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -949,6 +949,24 @@ var getToggle = function (toggleName, text) {
             css: {display: 'none', paddingLeft: '20px'}
         });
 
+        var disableall = $('<div/>', {
+            id: 'toggle-all-items-' + toggleName,
+            text: 'disable all',
+            css: {cursor: 'pointer',
+                  display: 'inline-block',
+                  textShadow: '3px 3px 4px gray'},
+        });
+
+        disableall.on('click', function () {
+            // can't use find as we only want one layer of checkboxes
+            var items = list.children().children(':checkbox');
+            items.prop('checked', false);
+            items.change();
+            list.children().children(':checkbox').change();
+        });
+
+        list.append(disableall);
+
         // fill out list with toggle items
         for (var itemName in auto.items) {
             if (toggleName === 'trade')

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -952,7 +952,7 @@ var getToggle = function (toggleName, text) {
         // fill out list with toggle items
         for (var itemName in auto.items) {
             if (toggleName === 'trade')
-                list.append(getTradeToggle(itemName, auto.items[itemName]));
+                list.append(getTradeOption(itemName, auto.items[itemName]));
             else if (toggleName === 'craft')
                 list.append(getCraftOption(itemName, auto.items[itemName]));
             else
@@ -998,26 +998,9 @@ var getToggle = function (toggleName, text) {
     return element;
 };
 
-var getTradeToggle = function (name, option) {
-    var element = $('<li/>', {
-        css: { borderBottom: '1px solid gray rgba(185, 185, 185,0.7)' },
-    });
-
-    var label = $('<label/>', {
-        'for': 'toggle-' + name,
-        text: ucfirst(name)
-    });
-
-    var input = $('<input/>', {
-        id: 'toggle-' + name,
-        type: 'checkbox'
-    });
-
-    if (option.enabled) {
-        input.prop('checked', 'checked');
-    }
-
-    element.append(input, label);
+var getTradeOption = function (name, option) {
+    var element = getOption(name, option);
+    element.css('borderBottom', '1px solid rgba(185, 185, 185, 0.7)');
 
     var button = $('<div/>', {
         id: 'toggle-seasons-' + name,

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -907,7 +907,7 @@ var getToggle = function (toggleName, text) {
     });
 
     if (auto.enabled) {
-        input.prop('checked', 'checked');
+        input.prop('checked', true);
     }
 
     // engine needs a custom toggle
@@ -1046,7 +1046,7 @@ var getSeason = function (name, season, option) {
     });
 
     if (option[season]) {
-        input.prop('checked', 'checked');
+        input.prop('checked', true);
     }
 
     input.on('change', function () {
@@ -1079,7 +1079,7 @@ var getOption = function (name, option) {
     });
 
     if (option.enabled) {
-        input.prop('checked', 'checked');
+        input.prop('checked', true);
     }
 
     input.on('change', function() {
@@ -1111,7 +1111,7 @@ var getCraftOption = function (name, option) {
     });
 
     if (option.limited) {
-        input.prop('checked', 'checked');
+        input.prop('checked', true);
     }
 
     input.on('change', function () {
@@ -1254,7 +1254,7 @@ var activityCheckbox = $('<input/>', {
 });
 
 if (options.showactivity)
-    activityCheckbox.prop('checked', 'checked');
+    activityCheckbox.prop('checked', true);
 
 activityCheckbox.on('change', function () {
     if (activityCheckbox.is(':checked')) {

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -913,10 +913,10 @@ var getToggle = function (toggleName, text) {
     // engine needs a custom toggle
     if (toggleName !== 'engine') {
         input.on('change', function () {
-            if (input.is(':checked')) {
+            if (input.is(':checked') && auto.enabled == false) {
                 auto.enabled = true;
                 message('Enabled Auto ' + ucfirst(text));
-            } else {
+            } else if (input.not(':checked') && auto.enabled == true) {
                 auto.enabled = false;
                 message('Disabled Auto ' + ucfirst(text));
             }
@@ -1050,10 +1050,10 @@ var getSeason = function (name, season, option) {
     }
 
     input.on('change', function () {
-        if (input.is(':checked')) {
+        if (input.is(':checked') && option[season] == false) {
             option[season] = true;
             message('Enabled trading with ' + ucfirst(name) + ' in the ' + ucfirst(season));
-        } else {
+        } else if (input.not(':checked') && option[season] == true) {
             option[season] = false;
             message('Disabled trading ' + ucfirst(name) + ' in the ' + ucfirst(season));
         }
@@ -1083,10 +1083,10 @@ var getOption = function (name, option) {
     }
 
     input.on('change', function() {
-        if (input.is(':checked')) {
+        if (input.is(':checked') && option.enabled == false) {
             option.enabled = true;
             message('Enabled Auto ' + ucfirst(name));
-        } else {
+        } else if (input.not(':checked') && option.enabled == true) {
             option.enabled = false;
             message('Disabled Auto ' + ucfirst(name));
         }
@@ -1115,10 +1115,10 @@ var getCraftOption = function (name, option) {
     }
 
     input.on('change', function () {
-        if (input.is(':checked')) {
+        if (input.is(':checked') && option.limited == false) {
             option.limited = true;
             message('Crafting ' + ucfirst(name) + ': limited once per season');
-        } else {
+        } else if (input.not(':checked') && option.limited == true) {
             option.limited = false;
             message('Crafting ' + ucfirst(name) + ': unlimited');
         }
@@ -1257,10 +1257,10 @@ if (options.showactivity)
     activityCheckbox.prop('checked', true);
 
 activityCheckbox.on('change', function () {
-    if (activityCheckbox.is(':checked')) {
+    if (activityCheckbox.is(':checked') && options.showactivity == false) {
         options.showactivity = true;
         message('Showing Kitten Scientists activity live');
-    } else {
+    } else if (activityCheckbox.not(':checked') && options.showactivity == true) {
         options.showactivity = false;
         message('Hiding updates of Kitten Scientists activity');
     }

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -812,7 +812,7 @@ var getAvailableStockOptions = function () {
 
         // Show only new resources that we don't have in the list and that are
         // visible. This helps cut down on total size.
-        if ($('#stock-' + res.name).length === 0 && res.visible) {
+        if ($('#stock-' + res.name).length === 0) {
             var item = $('<div/>', {
                 id: 'stock-add-' + name,
                 text: ucfirst(res.name),


### PR DESCRIPTION
Refactor trade options to use getOption internally. This fixes a bug related to races not being toggled on the checkbox, and also reduces some code duplication which caused this bug in the first place.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>