### PR TITLE
crafting: make consume only apply to capped resources

### DIFF
--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -470,11 +470,10 @@ CraftManager.prototype = {
     },
     getLowestCraftAmount: function (name) {
         var amount = 0;
-        var consume = options.consume;
         var materials = this.getMaterials(name);
 
         for (var i in materials) {
-            var total = this.getValueAvailable(i) * consume / materials[i];
+            var total = this.getValueAvailable(i) / materials[i];
 
             amount = (0 === amount || total < amount) ? total : amount;
         }
@@ -525,7 +524,13 @@ CraftManager.prototype = {
             if (resPerTick < 0) stock -= resPerTick * 202 * 5;
         }
 
-        return Math.max(value - stock, 0);
+        value = Math.max(value - stock, 0);
+
+        // If we have a maxValue, check consumption rate
+        if (this.getResource(name).maxValue > 0)
+            value /= options.consume;
+
+        return value;
     }
 };
 
@@ -559,12 +564,11 @@ TradeManager.prototype = {
     getLowestTradeAmount: function (name) {
         var amount = -1;
         var highestCapacity = undefined;
-        var consume = options.consume;
         var materials = this.getMaterials(name);
         var race = this.getRace(name);
 
         for (var i in materials) {
-            var total = this.craftManager.getValueAvailable(i) * consume / materials[i];
+            var total = this.craftManager.getValueAvailable(i) / materials[i];
 
             amount = (-1 === amount || total < amount) ? total : amount;
         }


### PR DESCRIPTION
It is rather annoying/meaningless for consume to apply to uncapped
resources, since we will simply craft a bunch in a row. This is sort of
mitigated by the once-per-season rule, but even with this, stocks are a
much better controller for this behavior.

Instead, make consume part of "getValueAvailable" (so each caller no
longer needs to handle it), and make it only apply to resources with a max
Value.

This makes getValueAvailable smarter now as well, since it will return the
current value we will use (ie: consume) instead of just how much is
available. It also makes it better at handling non-capped resources that
have stocks, since callers of stocked resources will always get how much
is available without the weird rule that you need "2x as much as you
actually need" issue.

Since the consumption really is only meaningful to capped resources (ie:
uncapped resources avoid triggers anwyays, so you will likely just ask to
use more later), just let the caller use all of the uncapped resource.

This also adds more weight to why the limiter system (once per season)
isn't very valuable especially with the current ability to modify stocks
more easily.