### PR TITLE
value: multiply by consume, not divide

### DIFF
--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -529,7 +529,7 @@ CraftManager.prototype = {
 
         // If we have a maxValue, check consumption rate
         if (this.getResource(name).maxValue > 0)
-            value /= options.consume;
+            value *= options.consume;
 
         return value;
     }


### PR DESCRIPTION
This resulted in incorrectly calculating the total amount of a resource
available as being twice as much as we actually had. Very bad for
business, as you can imagine.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>