### PR TITLE
getLowestCraftAmount: fix case where value available is 0

### DIFF
--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -469,13 +469,13 @@ CraftManager.prototype = {
         return game.workshop.getCraft(this.getName(name));
     },
     getLowestCraftAmount: function (name) {
-        var amount = 0;
+        var amount = undefined;
         var materials = this.getMaterials(name);
 
         for (var i in materials) {
             var total = this.getValueAvailable(i) / materials[i];
 
-            amount = (0 === amount || total < amount) ? total : amount;
+            amount = (amount === undefined || total < amount) ? total : amount;
         }
 
         return amount;
@@ -562,7 +562,7 @@ TradeManager.prototype = {
         activity('Kittens have traded ' + amount + 'x with ' + ucfirst(name));
     },
     getLowestTradeAmount: function (name) {
-        var amount = -1;
+        var amount = undefined;
         var highestCapacity = undefined;
         var materials = this.getMaterials(name);
         var race = this.getRace(name);
@@ -570,7 +570,7 @@ TradeManager.prototype = {
         for (var i in materials) {
             var total = this.craftManager.getValueAvailable(i) / materials[i];
 
-            amount = (-1 === amount || total < amount) ? total : amount;
+            amount = (amount === undefined || total < amount) ? total : amount;
         }
 
         if (race === null || options.auto.trade.items[name].allowuncapped) return Math.floor(amount);


### PR DESCRIPTION
The way that we cacluated the lowest amount resulted in ignoring any times
when getValue returned zero. This results in ignoring stock limits when
your available amount is below the stock. This is obviously not a good
thing.

Fix it so that we use undefined instead of 0 as the inializer check. Also,
fix getLowestTradeAmount in a similar way, though it actually seems to
have had a slightly different method to avoid this same problem. We want
to be consistent either way though.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>