### PR TITLE
trade: fix issue #61 leviathans trade

### DIFF
--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -583,7 +583,7 @@ TradeManager.prototype = {
             amount = (amount === undefined || total < amount) ? total : amount;
         }
 
-        if (race === null || options.auto.trade.items[name].allowuncapped) return Math.floor(amount);
+        if (race === null || options.auto.trade.items[name].allowcapped) return Math.floor(amount);
 
         // Loop through the items obtained by the race, and determine
         // which good has the most space left. Once we've determined this,


### PR DESCRIPTION
This patch fixes a typo of the use of allowuncapped instead of
allowcapped. This should (properly) fix leviathan trade.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>
Fixes: fdc6f02 ("issue #49: allow leviathans to trade even when capped")