### PR TITLE
crafting: prevent kittens from over-crafting wood

### DIFF
--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -476,12 +476,20 @@ CraftManager.prototype = {
     getLowestCraftAmount: function (name) {
         var amount = undefined;
         var materials = this.getMaterials(name);
+        var res = this.getResource(name);
 
         for (var i in materials) {
             var total = this.getValueAvailable(i) / materials[i];
 
             amount = (amount === undefined || total < amount) ? total : amount;
         }
+
+        // If we have a maximum value, ensure that we don't produce more than
+        // this value. This should currently only impact wood crafting, but is
+        // written generically to ensure it works for any craft that produces a
+        // good with a maximum value.
+        if (res.maxValue > 0 && amount > (res.maxValue - res.value))
+            amount = res.maxValue - res.value;
 
         return amount;
     },


### PR DESCRIPTION
In the rare case that wood is nearly at cap, prevent the scientists from
producing so much wood that we actually lose any. We should produce enough
to keep catnip from overflowing, while then nearly imemdiately crafting
wood into beams. This helps prevent a small loss in efficiency.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>