### PR TITLE
buildings: ignore consumption rate

### DIFF
--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -420,7 +420,7 @@ BuildManager.prototype = {
 
         for (var i in prices) {
             var price = prices[i];
-            var res = this.crafts.getValueAvailable(price.name);
+            var res = this.crafts.getValueAvailable(price.name, true);
             if (res < price.val) return false;
         }
 
@@ -531,7 +531,7 @@ CraftManager.prototype = {
 
         return !stock ? 0 : stock;
     },
-    getValueAvailable: function (name) {
+    getValueAvailable: function (name, all) {
         var value = this.getValue(name);
         var stock = this.getStock(name);
 
@@ -546,8 +546,9 @@ CraftManager.prototype = {
 
         value = Math.max(value - stock, 0);
 
-        // If we have a maxValue, check consumption rate
-        if (this.getResource(name).maxValue > 0) {
+        // If we have a maxValue, and user hasn't requested all, check
+        // consumption rate
+        if (!all && this.getResource(name).maxValue > 0) {
             var res = options.auto.resources[name];
             var consume = res.consume ? res.consume : options.consume;
 

--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -550,7 +550,7 @@ CraftManager.prototype = {
         // consumption rate
         if (!all && this.getResource(name).maxValue > 0) {
             var res = options.auto.resources[name];
-            var consume = res.consume ? res.consume : options.consume;
+            var consume = res && (res.consume != undefined) ? res.consume : options.consume;
 
             value *= consume;
         }


### PR DESCRIPTION
Buildings most generally want to be build even if it would consume more than
the 0.6 default amount. Add an "all" parameter, which will default to undefined
(false-y) and only set it to true for buildings. This should enable buildings
even if it would cost more than 60% of the available resources.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>