### PR TITLE
Add catpower value check to hunting

### DIFF
--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -305,7 +305,7 @@ Engine.prototype = {
     hunt: function () {
         var catpower = this.craftManager.getResource('catpower');
 
-        if (options.auto.hunt.trigger <= catpower.value / catpower.maxValue) {
+        if (options.auto.hunt.trigger <= catpower.value / catpower.maxValue && catpower.value >= 100) {
             // No way to send only some hunters. Thus, we hunt with everything
             storeForSummary('hunt', catpower.value);
             activity('Sent ' + game.getDisplayValueExt(catpower.value) + ' kittens on the hunt');


### PR DESCRIPTION
Prevent spamming the log in iron will mode (and early normal mode?
when trying to hunt with low maximum catpower by adding a direct check
on the current catpower value.

For reference, my log every time my catpower reaches 60 (in iron will mode, with 1 zebra) is this:

> Sent 100 kittens on the hunt
> Sent 99.000 kittens on the hunt
> Sent 97.500 kittens on the hunt
> Sent 96.000 kittens on the hunt
> *(20 lines removed)*
> Sent 64.650 kittens on the hunt
> Sent 63.150 kittens on the hunt
> Sent 61.650 kittens on the hunt
> Sent 60.150 kittens on the hunt