### PR TITLE
Bypass interface to observe stars

### DIFF
--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -222,7 +222,7 @@ Engine.prototype = {
         message('Disabling the kitten scientists!');
     },
     iterate: function () {
-        this.observeGameLog();
+        this.observeStars();
         if (options.auto.faith.enabled) this.praiseSun();
         if (options.auto.festival.enabled) this.holdFestival();
         if (options.auto.build.enabled) this.build();
@@ -288,13 +288,11 @@ Engine.prototype = {
             }
         }
     },
-    observeGameLog: function () {
-        // @TODO: determine if this can be accomplished outside the interface
-        var stars = $('#gameLog').find('input');
-        if (stars.length) {
-            storeForSummary('stars', stars.length);
+    observeStars: function () {
+       if (game.calendar.observeBtn != null){
+            game.calendar.observeHandler();
             activity('Kitten Scientists have observed a star');
-            stars.click();
+            storeForSummary('stars', 1); 
         }
     },
     praiseSun: function () {


### PR DESCRIPTION
I found the TODO and decided to act on it. This change checks the game.calendar object. If `game.calendar.observeBtn` is defined, there exists a button that can be pressed on the interface. 
Calling `game.calendar.observeHandler()` will trigger star observation and get rid of the button.

I wrote an alternative way to observe stars that adds a observer (using `Object.observe()`) to game.calendar to check for the update to `game.calendar.observeBtn`, but `game.calendar` gets updated about 10 times a tick, so sticking with Kitten Scientists' polling method may be superior, particularly for slow computers... but I figured it was worth sharing in case someone has considered changing Kitten Scientists to be event-based rather than polling. That branch can be seen here: https://github.com/sapid/cbc-kitten-scientists/tree/observeStars