### PR TITLE
Fix CSS insert crash

### DIFF
--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -742,7 +742,7 @@ right.css({
 
 var addRule = function (rule) {
     var sheets = document.styleSheets;
-    sheets[0].insertRule(rule, 1);
+    sheets[0].insertRule(rule, 0);
 };
 
 addRule('#gameLog .msg {'


### PR DESCRIPTION
I was getting this error, probably due to some extension that is filtering stuff out of the page:

`Uncaught IndexSizeError: Failed to execute 'insertRule' on 'CSSStyleSheet': The index provided (1) is larger than the maximum index (0).`

It seems like the script will keep working for everyone else.