### PR TITLE
Fix font size

### DIFF
--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -790,7 +790,7 @@ addRule('#resContainer .maxRes {'
 addRule('#game .btn {'
 + 'border-radius: 0px;'
 + 'font-family: monospace;'
-+ 'font-size: "10px";'
++ 'font-size: 13px !important;'
 + 'margin: 0 0 7px 0;'
 + '}');
 


### PR DESCRIPTION
This fixes multiple issues with the given line.

1. The quotes are invalid syntax, thus, making the whole rule void.
2. `10px` is too small IMHO
3. Without `!important`, the game will selectively apply `font-size: 90%` as an inline style to the buttons of building that can be toggled. This results in buttons having different heights and that just looks horrible!