### PR TITLE
Fix auto-trading no longer working

### DIFF
--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -378,6 +378,8 @@ Engine.prototype = {
         // Try our best not to starve any single race
         maxTrades = (trades.length > 0) ? Math.floor(maxTrades / trades.length) : 0;
 
+        if (maxTrades < 1) return;
+
         for (var i in trades) {
             var name = trades[i];
             tradeManager.trade(name, Math.min(tradeManager.getLowestTradeAmount(name), maxTrades));
@@ -651,7 +653,7 @@ TradeManager.prototype = {
                 max = Math.ceil(val);
             } else {
                 var sratio = item.seasons[game.calendar.getCurSeason().name];
-                var tratio = self.game.bld.getEffect("tradeRatio");
+                var tratio = game.bld.getEffect("tradeRatio");
                 var val = item.value + item.value * tratio;
 
                 max = val * sratio * (1 + item.delta/2);


### PR DESCRIPTION
`self` is a reference to the root element (`window`) and `game` points to a DOM element. That is not what is needed here. We actually want a different `game` object, which is directly accessible.

The `getEffect` call would cause an exception to be thrown and trading would never happen.

Additionally, we now bail out early if no trade is possible.