### PR TITLE
Clarify engine toggle

### DIFF
--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -1368,7 +1368,7 @@ var optionsTitleElement = $('<div/>', {
 
 optionsElement.append(optionsTitleElement);
 
-optionsListElement.append(getToggle('engine',   'Engine'));
+optionsListElement.append(getToggle('engine',   'Enable Scientists'));
 optionsListElement.append(getToggle('build',    'Building'));
 optionsListElement.append(getToggle('craft',    'Crafting'));
 optionsListElement.append(getToggle('trade',    'Trading'));


### PR DESCRIPTION
The "Engine" checkbox is not intuitively recognized as required to be checked for the scientists to go to work. A clearer label for the checkbox will improve the user experience for new users.