### PR TITLE
Don't recreate TabManager every frame

### DIFF
--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -230,12 +230,14 @@ var Engine = function () {
     this.buildManager = new BuildManager();
     this.craftManager = new CraftManager();
     this.tradeManager = new TradeManager();
+    this.villageManager = new TabManager('Small village');
 };
 
 Engine.prototype = {
     buildManager: undefined,
     craftManager: undefined,
     tradeManager: undefined,
+    villageManager: undefined,
     loop: undefined,
     start: function () {
         if (this.loop) return;
@@ -306,10 +308,8 @@ Engine.prototype = {
         }
     },
     holdFestival: function () {
-        var villageManager = new TabManager('Small village');
-
-        if (game.science.get('drama').researched && game.calendar.festivalDays === 0 && villageManager.tab.festivalBtn.hasResources()) {
-            villageManager.tab.festivalBtn.onClick();
+        if (game.science.get('drama').researched && game.calendar.festivalDays === 0 && this.villageManager.tab.festivalBtn.hasResources()) {
+            this.villageManager.tab.festivalBtn.onClick();
 
             if (game.calendar.festivalDays !== 0) {
                 storeForSummary('festival');


### PR DESCRIPTION
I'm not sure if there was a reason to re-create it every frame, but it had a serious impact on my performance, so I adjusted this.

I'm currently testing this change in my own fork. Feedback is welcome.