### PR TITLE
Show a message to users using the old script URL

### DIFF
--- a/kitten-scientists.js
+++ b/kitten-scientists.js
@@ -1,1 +1,1 @@
-kitten-scientists.user.js
+prompt('Your bookmarklet is outdated. Please replace it with the value below.', "javascript:(function(){var d=document,s=d.createElement('script');s.src='https://rawgit.com/cameroncondry/cbc-kitten-scientists/master/kitten-scientists.user.js';d.body.appendChild(s);})();");


### PR DESCRIPTION
The script file was renamed to better interact with userscript managers. Users with the bookmarklet would still reference the old file name. I attempted to solve that by using a symlink, but GitHub will not provide the raw content for a symlinked file, which would make the bookmarklet fail.