### PR TITLE
Show number of kittens sent to hunt, not catpower

### DIFF
--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -469,7 +469,8 @@ Engine.prototype = {
         if (options.auto.hunt.trigger <= catpower.value / catpower.maxValue && catpower.value >= 100) {
             // No way to send only some hunters. Thus, we hunt with everything
             storeForSummary('hunt', catpower.value);
-            activity('Sent ' + game.getDisplayValueExt(catpower.value) + ' kittens on the hunt', 'ks-hunt');
+            var hunters = game.village.getJob('hunter').value;
+            activity('Sent ' + hunters + ' kitten' + (hunters == 1 ? '' : 's') + ' on the hunt', 'ks-hunt');
             game.village.huntAll();
         }
     },


### PR DESCRIPTION
This modifies the `hunt()` function so that it looks up `game.village.getJob('hunter').value` instead of `game.getDisplayValueExt(catpower.value)` when recording hunts in the activity log, fixing #154.  The word "kittens" is correctly singularized when only one hunter is available.