### PR TITLE
The version should also be bumped to 1.3.1 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cbc-kitten-scientists",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Add-on for the wonderful incremental browser game: http://bloodrizer.ru/games/kittens/",
   "main": "kitten-scientists.js",
   "scripts": {


### PR DESCRIPTION
Since I bumped the version in kitten-scientists.user.js before. Well if we want to bump the version - but seems like a good idea when it supports a new version of Kittens Game