### PR TITLE
Fix display of Show activity checkbox on 1.3.0.0

### DIFF
--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -1759,6 +1759,10 @@ var run = function() {
         }
     });
 
+    var activityLabel = $('<label/>', {
+        for: 'enable-activity'
+    });
+
     if (options.showactivity)
         activityCheckbox.prop('checked', true);
 
@@ -1774,7 +1778,7 @@ var run = function() {
 
     showActivity.on('click', displayActivitySummary);
 
-    activityBox.append(activityCheckbox, showActivity);
+    activityBox.append(activityCheckbox, activityLabel, showActivity);
 
     $('#clearLog').append(activityBox);
 


### PR DESCRIPTION
The new styling of checkboxes on 1.3.0.0 is done by a css hack that assigns the image to a ::before element of the label for checkboxes. So without a label nothing is shown. So this just adds an empty label after the checkbox.