### PR TITLE
Corrected crash on start due to renderFilters move

### DIFF
--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -305,7 +305,7 @@ var run = function() {
         enabled: true,
         unlocked: true
     };
-    gameLog.renderFilters();
+    game.ui.renderFilters();
 
     var printoutput = function (args) {
         var color = args.pop();


### PR DESCRIPTION
renderFilters is now part of game.ui, was causing TypeError on start.

See this reddit thread:
https://www.reddit.com/r/kittensgame/comments/62r8nq/kitten_scientists_wont_start_typeerror_message/