### PR TITLE
Fix build issues with 1.4.0.6

### DIFF
--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -603,7 +603,7 @@ var run = function() {
             var label = typeof stage !== 'undefined' ? build.meta.stages[stage].label : build.meta.label;
 
             for (var i in buttons) {
-                if (buttons[i].name === label) return buttons[i];
+                if (buttons[i].model.name === label) return buttons[i];
             }
         }
     };

--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -271,7 +271,8 @@ var run = function() {
         // add the second css tag to the newest element in the log.
         var gameLog = dojo.byId("gameLog");
         while (t = type.pop()) {
-            gameLog.childNodes[0].addClass(span, "type_"+t);
+            span = gameLog.childNodes[0];
+            dojo.addClass(span, "type_"+t);
         }
     };
 

--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -265,6 +265,7 @@ var run = function() {
     // it returns the DOM node for the last created message, it doesn't really
     // do that. (Liars.) So some hackery is needed to do this right.
     gameLog.msg = function (message, type, tag, noBullet) {
+        type = type.split(",");
         game.msg(message, type.pop(), tag, noBullet);
         // since that doesn't return anything, we'll just assume it worked and
         // add the second css tag to the newest element in the log.

--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -603,7 +603,7 @@ var run = function() {
             var label = typeof stage !== 'undefined' ? build.meta.stages[stage].label : build.meta.label;
 
             for (var i in buttons) {
-                if (buttons[i].model.name === label) return buttons[i];
+                if (buttons[i].opts.name === label) return buttons[i];
             }
         }
     };


### PR DESCRIPTION
This seems to have been a simple issue with the location of button "name" strings having been moved to a number of child properties, causing the `getBuildButton` function in the `BuildManager` prototype to not be able to find button names. In the final commit, I chose the one that seemed stable and returned the correct string.

For what its worth, being completely unfamiliar with the code prior to this commit, I could not figure out where `this.manager.tab.buttons` was being loaded from; I only assume that it's pulling from a game script that was modified with this latest update. Curious to know whether that's correct.