### PR TITLE
Fix multi-type activity messages

### DIFF
--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -285,7 +285,7 @@ var run = function() {
     var activity = function () {
         if (options.showactivity) {
             var args = Array.prototype.slice.call(arguments);
-            var activityClass = args.length > 1 ? ',' + args.pop() : '';
+            var activityClass = args.length > 1 ? ' type_' + args.pop() : '';
             args.push('ks-activity' + activityClass);
             args.push(options.activitycolor);
             printoutput(args);


### PR DESCRIPTION
Missed this part of the console.msg override, KS activity messages can have multiple types (like praising). This in effect sets the log element's className like it did before, and still without needing to override the game's methods.