### PR TITLE
Always load craft settings over defaults

### DIFF
--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -1030,12 +1030,12 @@ var run = function() {
 
                 if ($('#resource-' + resource).length === 0) {
                     list.append(addNewResourceOption(resource));
-                    if ('stock' in res) {
-                        setStockValue(resource, res.stock);
-                    }
-                    if ('consume' in res) {
-                        setConsumeRate(resource, res.consume);
-                    }
+                }
+                if ('stock' in res) {
+                    setStockValue(resource, res.stock);
+                }
+                if ('consume' in res) {
+                    setConsumeRate(resource, res.consume);
                 }
             }
 


### PR DESCRIPTION
Furs and unobtainium wouldn't load their stock/consume settings from localStorage since their list elements existed already.