### PR TITLE
Ensure tab has rendered so we can click button

### DIFF
--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -422,6 +422,9 @@ var run = function() {
             }
         },
         holdFestival: function () {
+            // Render the tab to make sure that the buttons actually exist in the DOM. Otherwise we can't click them.
+            game.villageTab.render();
+
             if (game.science.get('drama').researched && game.calendar.festivalDays === 0 && game.villageTab.festivalBtn.model.enabled) {
                 game.villageTab.festivalBtn.onClick();
                 if (game.calendar.festivalDays !== 0) {


### PR DESCRIPTION
The previous fix for #209 more or less solved the problem but sort of by accident. When the game first starts `festivalBtn` still doesn't exist so we trigger the same error. Eventually the game creates the button and the problem goes away. This change forces the tab to render so the button is always available.