### PR TITLE
Update logic for getting religion buttons

### DIFF
--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -598,7 +598,10 @@ var run = function() {
             var build = this.getBuild(name);
 
             for (var i in buttons) {
-                if (buttons[i].name === build.label) return buttons[i];
+                var haystack = buttons[i].model.name;
+                if (haystack.indexOf(build.label) !== -1){
+                    return buttons[i];
+                }
             }
         }
     };
@@ -637,7 +640,7 @@ var run = function() {
 
             for (var i in buttons) {
                 var haystack = buttons[i].model.name;
-                if(haystack.indexOf(label) !== -1){
+                if (haystack.indexOf(label) !== -1){
                     return buttons[i];
                 }
             }


### PR DESCRIPTION
I finally got a chance to do a reset and watch the religion code in action. Turns out, it doesn't work. The logic for storing the button's label has changed, this changes the ReligionManager to match the BuildingManager logic so it can find the buttons to click on.