### PR TITLE
Use season id for limited crafting

### DIFF
--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -444,7 +444,7 @@ var run = function() {
                 var craft = crafts[name];
                 var current = !craft.max ? false : manager.getResource(name);
                 var require = !craft.require ? false : manager.getResource(craft.require);
-                var season = game.calendar.getCurSeason().name;
+                var season = game.calendar.season;
 
                 // Ensure that we have reached our cap
                 if (current && current.value > craft.max) continue;


### PR DESCRIPTION
During the "Winter Has Come" challenge the calendar display name is always "Winter". This causes the limited crafting option to never craft things as the season doesn't change. If we instead use the season ID this will work in all situations as that still goes from 0 to 3 like normal.