### PR TITLE
WIP : Modification of the "limited" flag on crafting

### DIFF
--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -440,12 +440,6 @@ var run = function() {
             var manager = this.craftManager;
             var trigger = options.auto.craft.trigger;
 
-            console.log("=====");
-            console.log(crafts);
-            for (var name in crafts) {
-              console.log("name : " + name);
-            }
-            console.log("-----");
             for (var name in crafts) {
                 var craft = crafts[name];
                 var current = !craft.max ? false : manager.getResource(name);
@@ -455,25 +449,18 @@ var run = function() {
                 // Ensure that we have reached our cap
                 if (current && current.value > craft.max) continue;
 
-                // Enforce season limited on specific crafts
-                if (craft.limited && craft.lastSeason === season) continue;
-
                 // Craft the resource if we meet the trigger requirement
                 if (!require || trigger <= require.value / require.maxValue) {
-                    var amount = Math.floor(manager.getLimitedLowestCraftAmount(name));
+                    var amount = Math.floor(craft.limited ? manager.getLimitedLowestCraftAmount(name) : manager.getLowestCraftAmount(name));
 
-                    console.log("name : " + name + ", amount : " + amount);
+                    // console.log("name : " + name + ", amount : " + amount + ", limited : " + craft.limited + ", vanilla : " + manager.getLowestCraftAmount(name) + ", modified : " +  manager.getLimitedLowestCraftAmount(name));
 
-                    // Only update season if we actually craft anything.
                     if (amount > 0) {
-                        manager.craft(name, manager.getLimitedLowestCraftAmount(name));
-
-                        // Store the season for future reference
-                        craft.lastSeason = season;
+                        manager.craft(name, amount);
                     }
                 }
             }
-            console.log("=====");
+            // console.log("=====");
         },
         holdFestival: function () {
             // Render the tab to make sure that the buttons actually exist in the DOM. Otherwise we can't click them.
@@ -777,23 +764,23 @@ var run = function() {
                 // Only craft "half" (TODO: document this behaviour)
                 // Use res.name or res.title ?
                 // if(name !== 'steel') return 0; // Test only one material at a time
-                console.log("==========");
-                console.log("b : " + name);
+                // console.log("==========");
+                // console.log("b : " + name);
 
                 var delta = undefined;
                 if(this.getResource(i).maxValue > 0) {
                     // If there is a storage limit, we can just use everything returned by getValueAvailable
-                    console.log("a : " + i + " (limited storage)");
+                    // console.log("a : " + i + " (limited storage)");
                     delta = this.getValueAvailable(i) / materials[i];
                 } else {
-                    console.log("a : " + i + " (unlimited storage)");
+                    // console.log("a : " + i + " (unlimited storage)");
                     // Take the currently present amount of material to craft into account
                     delta = (this.getValueAvailable(i) - materials[i] * this.getValueAvailable(res.name)) / (2 * materials[i]);
                 }
-                console.log(delta);
+                // console.log(delta);
 
                 amount = (amount === undefined || delta < amount) ? delta : amount;
-                console.log("==========");
+                // console.log("==========");
             }
 
             // If we have a maximum value, ensure that we don't produce more than

--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -440,6 +440,12 @@ var run = function() {
             var manager = this.craftManager;
             var trigger = options.auto.craft.trigger;
 
+            console.log("=====");
+            console.log(crafts);
+            for (var name in crafts) {
+              console.log("name : " + name);
+            }
+            console.log("-----");
             for (var name in crafts) {
                 var craft = crafts[name];
                 var current = !craft.max ? false : manager.getResource(name);
@@ -456,6 +462,8 @@ var run = function() {
                 if (!require || trigger <= require.value / require.maxValue) {
                     var amount = Math.floor(manager.getLimitedLowestCraftAmount(name));
 
+                    console.log("name : " + name + ", amount : " + amount);
+
                     // Only update season if we actually craft anything.
                     if (amount > 0) {
                         manager.craft(name, manager.getLimitedLowestCraftAmount(name));
@@ -465,6 +473,7 @@ var run = function() {
                     }
                 }
             }
+            console.log("=====");
         },
         holdFestival: function () {
             // Render the tab to make sure that the buttons actually exist in the DOM. Otherwise we can't click them.
@@ -769,23 +778,22 @@ var run = function() {
                 // Use res.name or res.title ?
                 // if(name !== 'steel') return 0; // Test only one material at a time
                 console.log("==========");
+                console.log("b : " + name);
 
                 var delta = undefined;
                 if(this.getResource(i).maxValue > 0) {
-                  // If there is a storage limit, we can just use everything returned by getValueAvailable
-                  console.log('a');
-                  delta = this.getValueAvailable(i) / materials[i];
+                    // If there is a storage limit, we can just use everything returned by getValueAvailable
+                    console.log("a : " + i + " (limited storage)");
+                    delta = this.getValueAvailable(i) / materials[i];
                 } else {
-                  console.log('b');
-                  // Take the currently present amount of material to craft into account
-                  delta = (this.getValueAvailable(i) - materials[i] * this.getValueAvailable(res.name)) / (2 * materials[i]);
+                    console.log("a : " + i + " (unlimited storage)");
+                    // Take the currently present amount of material to craft into account
+                    delta = (this.getValueAvailable(i) - materials[i] * this.getValueAvailable(res.name)) / (2 * materials[i]);
                 }
-                console.log("b : " + name);
-                console.log("a : " + i);
                 console.log(delta);
-                console.log("==========");
 
                 amount = (amount === undefined || delta < amount) ? delta : amount;
+                console.log("==========");
             }
 
             // If we have a maximum value, ensure that we don't produce more than

--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -725,7 +725,7 @@ var run = function() {
             return game.workshop.getCraft(this.getName(name));
         },
         getLowestCraftAmount: function (name, limited) {
-            var amount = undefined;
+            var amount = Number.MAX_VALUE;
             var materials = this.getMaterials(name);
 
             // Safeguard if materials for craft cannot be determined.
@@ -744,7 +744,7 @@ var run = function() {
                     delta = (this.getValueAvailable(i) - materials[i] * this.getValueAvailable(res.name)) / (2 * materials[i]);
                 }
 
-                amount = (amount === undefined || delta < amount) ? delta : amount;
+                amount = Math.min(delta,amount);
             }
 
             // If we have a maximum value, ensure that we don't produce more than

--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -453,14 +453,11 @@ var run = function() {
                 if (!require || trigger <= require.value / require.maxValue) {
                     var amount = Math.floor(craft.limited ? manager.getLimitedLowestCraftAmount(name) : manager.getLowestCraftAmount(name));
 
-                    // console.log("name : " + name + ", amount : " + amount + ", limited : " + craft.limited + ", vanilla : " + manager.getLowestCraftAmount(name) + ", modified : " +  manager.getLimitedLowestCraftAmount(name));
-
                     if (amount > 0) {
                         manager.craft(name, amount);
                     }
                 }
             }
-            // console.log("=====");
         },
         holdFestival: function () {
             // Render the tab to make sure that the buttons actually exist in the DOM. Otherwise we can't click them.
@@ -761,26 +758,17 @@ var run = function() {
             var res = this.getResource(name);
 
             for (var i in materials) {
-                // Only craft "half" (TODO: document this behaviour)
-                // Use res.name or res.title ?
-                // if(name !== 'steel') return 0; // Test only one material at a time
-                // console.log("==========");
-                // console.log("b : " + name);
-
                 var delta = undefined;
                 if(this.getResource(i).maxValue > 0) {
                     // If there is a storage limit, we can just use everything returned by getValueAvailable
-                    // console.log("a : " + i + " (limited storage)");
                     delta = this.getValueAvailable(i) / materials[i];
                 } else {
-                    // console.log("a : " + i + " (unlimited storage)");
                     // Take the currently present amount of material to craft into account
+                    // Only craft "half" (TODO: document this behaviour)
                     delta = (this.getValueAvailable(i) - materials[i] * this.getValueAvailable(res.name)) / (2 * materials[i]);
                 }
-                // console.log(delta);
 
                 amount = (amount === undefined || delta < amount) ? delta : amount;
-                // console.log("==========");
             }
 
             // If we have a maximum value, ensure that we don't produce more than

--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -767,14 +767,23 @@ var run = function() {
             for (var i in materials) {
                 // Only craft "half" (TODO: document this behaviour)
                 // Use res.name or res.title ?
-                var delta = (this.getValueAvailable(i) - materials[i] * this.getValueAvailable(res.name)) / (2 * materials[i]);
-                // console.log("==========");
-                // console.log("b : " + name);
-                // console.log(res);
-                // console.log(i);
-                // console.log(materials);
-                // console.log(delta);
-                // console.log("==========");
+                // if(name !== 'steel') return 0; // Test only one material at a time
+                console.log("==========");
+
+                var delta = undefined;
+                if(this.getResource(i).maxValue > 0) {
+                  // If there is a storage limit, we can just use everything returned by getValueAvailable
+                  console.log('a');
+                  delta = this.getValueAvailable(i) / materials[i];
+                } else {
+                  console.log('b');
+                  // Take the currently present amount of material to craft into account
+                  delta = (this.getValueAvailable(i) - materials[i] * this.getValueAvailable(res.name)) / (2 * materials[i]);
+                }
+                console.log("b : " + name);
+                console.log("a : " + i);
+                console.log(delta);
+                console.log("==========");
 
                 amount = (amount === undefined || delta < amount) ? delta : amount;
             }


### PR DESCRIPTION
Hi everybody !

This pull request introduces a different approach to the "Limited" flag in automatic crafting.

So, my understanding of this option is that we want to limit the consumption of resources used in crafting, so that we can still have some of the original resource (example : I want to automatically craft scaffolds, but still have some beams for other uses)

The current system limits to one craft per season, which is not really efficient.

My proposal is to remove any dependency to time, and instead, only rely on the craft ratio and current amounts of each material, to maintain them in "equal" proportions.

For example, knowing that the conversion ratio is 50 beam -> 1 scaffold, if we enable the scaffold crafting with the "limited" flag, here is what would happen : 

|beam (initial)|scaffold (initial)|beam (final)|scaffold (final)|
|-------|----------|-|-|
|1000|0|500|10|
|750|5|500|10|
|500|10|500|10|
|250|15|250|15|

In case of multiple sources, the lowest amount is kept.
The resources with a maximum value are also treated separately (as they were before).

That's it for the rough idea, there are a few things still missing : 
- The actual crafting ratio (with craft effectiveness upgrades) is not taken into account, so we might occasionally craft too much of the target resource. It would be better to directly use the actual ratio.
- After using it for a bit, I think it keeps too much of the source resource. I'm thinking about adding a configurable ratio for this.

So, what do you guys think about this ? I'd like to have some advice on it before continuing.