### PR TITLE
add check to stock settings before building

### DIFF
--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -411,6 +411,12 @@ var run = function() {
                 var require = !build.require ? false : craftManager.getResource(build.require);
 
                 if (!require || trigger <= require.value / require.maxValue) {
+                    // verify that the building prices is within the current stock settings
+                    var prices = game.bld.getPrices(name);
+                    for (var p = 0; p < prices.length; p++) {
+                        if (craftManager.getValueAvailable(prices[p].name, true) < prices[p].val) continue;
+                    }
+
                     // If the build overrides the name, use that name instead.
                     // This is usually true for buildings that can be upgraded.
                     buildManager.build(build.name || name, build.stage);


### PR DESCRIPTION
This patch stems from my annoyance at KS using my stockpiled resources for buildings. This adds a check that makes buildings respect the resource "stock" settings. I verified that it worked, if there are other unit tests or whatever that should be examined as well then please let me know how to do that.