### PR TITLE
Fixing The Enable-All Button/At least one Trade Error

### DIFF
--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -662,7 +662,9 @@ var run = function() {
             var tradeManager = this.tradeManager;
             var gold = craftManager.getResource('gold');
             var trades = [];
-
+            
+            tradeManager.manager.render();
+            
             // Only trade if it's enabled
             if (!options.auto.trade.enabled) return;
 
@@ -1134,8 +1136,6 @@ var run = function() {
     var TradeManager = function () {
         this.craftManager = new CraftManager();
         this.manager = new TabManager('Trade');
-
-        this.manager.render();
     };
 
     TradeManager.prototype = {
@@ -1149,7 +1149,7 @@ var run = function() {
 
             if (!race.unlocked) return;
 
-            var button = this.getTradeButton(race.title);
+            var button = this.getTradeButton(race.name);
 
             if (!button.model.enabled || !options.auto.trade.items[name].enabled) return;
 
@@ -1240,7 +1240,7 @@ var run = function() {
             for (var i in this.manager.tab.racePanels) {
                 var panel = this.manager.tab.racePanels[i];
 
-                if (panel.name.indexOf(race) > -1) return panel.tradeBtn;
+                if (panel.race.name === race) return panel.tradeBtn;
             }
 
             warning('unable to find trade button for ' + name);

--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -1721,7 +1721,7 @@ var run = function() {
                     auto.enabled = true;
                     message('Enabled Auto ' + ucfirst(text));
                     saveToKittenStorage();
-                } else if (input.not(':checked') && auto.enabled == true) {
+                } else if ((!input.is(':checked')) && auto.enabled == true) {
                     auto.enabled = false;
                     message('Disabled Auto ' + ucfirst(text));
                     saveToKittenStorage();
@@ -1923,7 +1923,7 @@ var run = function() {
             if (input.is(':checked') && option[season] == false) {
                 option[season] = true;
                 message('Enabled trading with ' + ucfirst(name) + ' in the ' + ucfirst(season));
-            } else if (input.not(':checked') && option[season] == true) {
+            } else if ((!input.is(':checked')) && option[season] == true) {
                 option[season] = false;
                 message('Disabled trading ' + ucfirst(name) + ' in the ' + ucfirst(season));
             }
@@ -1959,7 +1959,7 @@ var run = function() {
             if (input.is(':checked') && option.enabled == false) {
                 option.enabled = true;
                 message('Enabled Auto ' + elementLabel);
-            } else if (input.not(':checked') && option.enabled == true) {
+            } else if ((!input.is(':checked')) && option.enabled == true) {
                 option.enabled = false;
                 message('Disabled Auto ' + elementLabel);
             }
@@ -1993,7 +1993,7 @@ var run = function() {
             if (input.is(':checked') && option.limited == false) {
                 option.limited = true;
                 message('Crafting ' + ucfirst(name) + ': limited to be proportional to cost ratio');
-            } else if (input.not(':checked') && option.limited == true) {
+            } else if ((!input.is(':checked')) && option.limited == true) {
                 option.limited = false;
                 message('Crafting ' + ucfirst(name) + ': unlimited');
             }

--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -1243,7 +1243,7 @@ var run = function() {
                 if (panel.race.name === race) return panel.tradeBtn;
             }
 
-            warning('unable to find trade button for ' + name);
+            warning('unable to find trade button for ' + race);
         }
     };
 


### PR DESCRIPTION
I found the cause of the long-standing enable-all bug, where clicking enable-all would enable everything but then instantaneously disable it referenced in #155 , #160 , and possibly #159. It appears that the cause was that enabling used .is() while disabling used .not(), and while .is() leaves the property intact, .not() deletes it if it finds it. The enable-all and disable-all buttons would call these twice at one point, so clicking enable-all would have .not(':checked') return false, delete the 'checked' property, then .not(':checked') would return true and it would toggle the buildings off. At least that is my understanding of what was going on. Regardless, changing the input.not() to !input.is() fixed the issue.