### PR TITLE
Automated Research, Workshop Upgrades, and Building Stage Upgrades

### DIFF
--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -603,45 +603,48 @@ var run = function() {
             }
             
             if (upgrades.buildings.enabled) {
-                
-                if (game.bld.getBuildingExt('pasture').meta.stage === 0) {
-                    if (game.bld.getBuildingExt('pasture').meta.stages[1].stageUnlocked) {
-                        game.bld.getBuildingExt('pasture').meta.on = 0;
-                        game.bld.getBuildingExt('pasture').meta.val = 0;
-                        game.bld.getBuildingExt('pasture').meta.stage = 1;
+                var pastureMeta = game.bld.getBuildingExt('pasture').meta;
+                if (pastureMeta.stage === 0) {
+                    if (pastureMeta.stages[1].stageUnlocked) {
+                        pastureMeta.on = 0;
+                        pastureMeta.val = 0;
+                        pastureMeta.stage = 1;
                         game.render();
                         activity('Upgraded pastures to solar farms!', 'ks-upgrade');
                     }
                 }
                 
-                if (game.bld.getBuildingExt('aqueduct').meta.stage === 0) {
-                    if (game.bld.getBuildingExt('aqueduct').meta.stages[1].stageUnlocked) {
-                        game.bld.getBuildingExt('aqueduct').meta.on = 0
-                        game.bld.getBuildingExt('aqueduct').meta.val = 0
-                        game.bld.getBuildingExt('aqueduct').meta.stage = 1
-                        game.bld.getBuildingExt('aqueduct').meta.calculateEffects(game.bld.getBuildingExt('aqueduct').meta, game)
+                var aqueductMeta = game.bld.getBuildingExt('aqueduct').meta;
+                if (aqueductMeta.stage === 0) {
+                    if (aqueductMeta.stages[1].stageUnlocked) {
+                        aqueductMeta.on = 0
+                        aqueductMeta.val = 0
+                        aqueductMeta.stage = 1
+                        aqueductMeta.calculateEffects(aqueductMeta, game)
                         game.render()
                         activity('Upgraded aqueducts to hydro plants!', 'ks-upgrade');
                     }
                 }
                 
-                if (game.bld.getBuildingExt('library').meta.stage === 0) {
-                    if (game.bld.getBuildingExt('library').meta.stages[1].stageUnlocked) {
-                        game.bld.getBuildingExt('library').meta.on = 0
-                        game.bld.getBuildingExt('library').meta.val = 0
-                        game.bld.getBuildingExt('library').meta.stage = 1
-                        game.bld.getBuildingExt('library').meta.calculateEffects(game.bld.getBuildingExt('library').meta, game)
+                var libraryMeta = game.bld.getBuildingExt('library').meta;
+                if (libraryMeta.stage === 0) {
+                    if (libraryMeta.stages[1].stageUnlocked) {
+                        libraryMeta.on = 0
+                        libraryMeta.val = 0
+                        libraryMeta.stage = 1
+                        libraryMeta.calculateEffects(libraryMeta, game)
                         game.render()
                         activity('Upgraded libraries to data centers!', 'ks-upgrade');
                     }
                     
                 }
                 
-                if (game.bld.getBuildingExt('amphitheatre').meta.stage === 0) {
-                    if (game.bld.getBuildingExt('amphitheatre').meta.stages[1].stageUnlocked) {
-                        game.bld.getBuildingExt('amphitheatre').meta.on = 0
-                        game.bld.getBuildingExt('amphitheatre').meta.val = 0
-                        game.bld.getBuildingExt('amphitheatre').meta.stage = 1
+                var amphitheatreMeta = game.bld.getBuildingExt('amphitheatre').meta;
+                if (amphitheatreMeta.stage === 0) {
+                    if (amphitheatreMeta.stages[1].stageUnlocked) {
+                        amphitheatreMeta.on = 0
+                        amphitheatreMeta.val = 0
+                        amphitheatreMeta.stage = 1
                         game.render()
                         activity('Upgraded amphitheatres to broadcast towers!', 'ks-upgrade');
                     }

--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -610,6 +610,7 @@ var run = function() {
                         game.bld.getBuildingExt('pasture').meta.val = 0;
                         game.bld.getBuildingExt('pasture').meta.stage = 1;
                         game.render();
+                        activity('Upgraded pastures to solar farms!', 'ks-upgrade');
                     }
                 }
                 
@@ -620,6 +621,7 @@ var run = function() {
                         game.bld.getBuildingExt('aqueduct').meta.stage = 1
                         game.bld.getBuildingExt('aqueduct').meta.calculateEffects(game.bld.getBuildingExt('aqueduct').meta, game)
                         game.render()
+                        activity('Upgraded aqueducts to hydro plants!', 'ks-upgrade');
                     }
                 }
                 
@@ -630,6 +632,7 @@ var run = function() {
                         game.bld.getBuildingExt('library').meta.stage = 1
                         game.bld.getBuildingExt('library').meta.calculateEffects(game.bld.getBuildingExt('library').meta, game)
                         game.render()
+                        activity('Upgraded libraries to data centers!', 'ks-upgrade');
                     }
                     
                 }
@@ -640,6 +643,7 @@ var run = function() {
                         game.bld.getBuildingExt('amphitheatre').meta.val = 0
                         game.bld.getBuildingExt('amphitheatre').meta.stage = 1
                         game.render()
+                        activity('Upgraded amphitheatres to broadcast towers!', 'ks-upgrade');
                     }
                 }
             }

--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -571,9 +571,10 @@ var run = function() {
             var upgradeManager = this.upgradeManager;
             var craftManager = this.craftManager;
             
-            buildManager.manager.render();
+            upgradeManager.workManager.render();
+          	upgradeManager.sciManager.render();
             
-            if (upgrades.upgrades.enabled) {
+            if (upgrades.upgrades.enabled && gamePage.tabs[3].visible) {
                 var work = game.workshop.upgrades;
                 workLoop:
                 for (var upg in work) {
@@ -587,7 +588,7 @@ var run = function() {
                 }
             }
             
-            if(upgrades.techs.enabled) {
+            if(upgrades.techs.enabled && gamePage.tabs[2].visible) {
                 var tech = game.science.techs;
                 techLoop:
                 for (var upg in tech) {
@@ -977,7 +978,7 @@ var run = function() {
             }
             for (var i in buttons) {
                 var haystack = buttons[i].model.name;
-                if (haystack.indexOf(upgrade.label) !== -1) {
+                if (haystack === upgrade.label) {
                     return buttons[i];
                 }
             }

--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -337,8 +337,8 @@ var run = function() {
                 //Should KS automatically upgrade?
                 enabled: false,
                 items: {
-                    workshop:  {enabled: false},
-                    science:   {enabled: false},
+                    upgrades:  {enabled: false},
+                    techs:     {enabled: false},
                     buildings: {enabled: false}
                 }
             },
@@ -573,7 +573,7 @@ var run = function() {
             
             buildManager.manager.render();
             
-            if (upgrades.workshop.enabled) {
+            if (upgrades.upgrades.enabled) {
                 var work = game.workshop.upgrades;
                 workLoop:
                 for (var upg in work) {
@@ -583,11 +583,11 @@ var run = function() {
                     for (var resource in prices) {
                         if (craftManager.getValueAvailable(prices[resource].name, true) < prices[resource].val) {continue workLoop;}
                     }
-                    upgradeManager.upgrade(work[upg], 'workshop');
+                    upgradeManager.build(work[upg], 'workshop');
                 }
             }
             
-            if(upgrades.science.enabled) {
+            if(upgrades.techs.enabled) {
                 var tech = game.science.techs;
                 techLoop:
                 for (var upg in tech) {
@@ -597,7 +597,7 @@ var run = function() {
                     for (var resource in prices) {
                         if (craftManager.getValueAvailable(prices[resource].name, true) < prices[resource].val) {continue techLoop;}
                     }
-                    upgradeManager.upgrade(tech[upg], 'science');
+                    upgradeManager.build(tech[upg], 'science');
                 }
             }
             
@@ -971,11 +971,9 @@ var run = function() {
         },
         getBuildButton: function (upgrade, variant) {
             if (variant === 'workshop') {
-                var buttons = this.workManager.tab;
-                intentionalError;
+                var buttons = this.workManager.tab.buttons;
             } else if (variant === 'science') {
-                var buttons = this.sciManager.tab;
-                intentionalError;
+                var buttons = this.sciManager.tab.buttons;
             }
             for (var i in buttons) {
                 var haystack = buttons[i].model.name;

--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -572,7 +572,7 @@ var run = function() {
             var craftManager = this.craftManager;
             
             upgradeManager.workManager.render();
-          	upgradeManager.sciManager.render();
+            upgradeManager.sciManager.render();
             
             if (upgrades.upgrades.enabled && gamePage.tabs[3].visible) {
                 var work = game.workshop.upgrades;
@@ -602,8 +602,47 @@ var run = function() {
                 }
             }
             
-            //if (upgrades.buildings.enabled) {
-            //}
+            if (upgrades.buildings.enabled) {
+                
+                if (game.bld.getBuildingExt('pasture').meta.stage === 0) {
+                    if (game.bld.getBuildingExt('pasture').meta.stages[1].stageUnlocked) {
+                        game.bld.getBuildingExt('pasture').meta.on = 0;
+                        game.bld.getBuildingExt('pasture').meta.val = 0;
+                        game.bld.getBuildingExt('pasture').meta.stage = 1;
+                        game.render();
+                    }
+                }
+                
+                if (game.bld.getBuildingExt('aqueduct').meta.stage === 0) {
+                    if (game.bld.getBuildingExt('aqueduct').meta.stages[1].stageUnlocked) {
+                        game.bld.getBuildingExt('aqueduct').meta.on = 0
+                        game.bld.getBuildingExt('aqueduct').meta.val = 0
+                        game.bld.getBuildingExt('aqueduct').meta.stage = 1
+                        game.bld.getBuildingExt('aqueduct').meta.calculateEffects(game.bld.getBuildingExt('aqueduct').meta, game)
+                        game.render()
+                    }
+                }
+                
+                if (game.bld.getBuildingExt('library').meta.stage === 0) {
+                    if (game.bld.getBuildingExt('library').meta.stages[1].stageUnlocked) {
+                        game.bld.getBuildingExt('library').meta.on = 0
+                        game.bld.getBuildingExt('library').meta.val = 0
+                        game.bld.getBuildingExt('library').meta.stage = 1
+                        game.bld.getBuildingExt('library').meta.calculateEffects(game.bld.getBuildingExt('library').meta, game)
+                        game.render()
+                    }
+                    
+                }
+                
+                if (game.bld.getBuildingExt('amphitheatre').meta.stage === 0) {
+                    if (game.bld.getBuildingExt('amphitheatre').meta.stages[1].stageUnlocked) {
+                        game.bld.getBuildingExt('pasture').meta.on = 0
+                        game.bld.getBuildingExt('pasture').meta.val = 0
+                        game.bld.getBuildingExt('pasture').meta.stage = 1
+                        game.render()
+                    }
+                }
+            }
         },
         build: function () {
             var builds = options.auto.build.items;

--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -636,9 +636,9 @@ var run = function() {
                 
                 if (game.bld.getBuildingExt('amphitheatre').meta.stage === 0) {
                     if (game.bld.getBuildingExt('amphitheatre').meta.stages[1].stageUnlocked) {
-                        game.bld.getBuildingExt('pasture').meta.on = 0
-                        game.bld.getBuildingExt('pasture').meta.val = 0
-                        game.bld.getBuildingExt('pasture').meta.stage = 1
+                        game.bld.getBuildingExt('amphitheatre').meta.on = 0
+                        game.bld.getBuildingExt('amphitheatre').meta.val = 0
+                        game.bld.getBuildingExt('amphitheatre').meta.stage = 1
                         game.render()
                     }
                 }


### PR DESCRIPTION
This is a new menu that allows KS to automatically research available technologies and workshop upgrades when it has the necessary resources. Furthermore, it also has an option to automatically upgrade buildings when possible (such as amphitheatres to broadcast towers) skipping the usual confirmation prompt. 

These settings are particularly useful when frequently resetting to farm paragon using chronospheres, since as soon as KS builds one library, it will instantly purchase all techs if enough resources were carried over, and as soon as it builds a workshop, it will do the same for workshop upgrades. Though these could be useful for more early game players if they want to purchase techs and workshop upgrades whenever possible.