### PR TITLE
Bulk Building, an Overhaul of Automated Building

### DIFF
--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -659,9 +659,38 @@ var run = function() {
 
             // Render the tab to make sure that the buttons actually exist in the DOM. Otherwise we can't click them.
             buildManager.manager.render();
-
+            
+            var bList = [];
+          	var i=0;
+            for (name in builds) {
+              	var build = builds[name];
+                if (!build.enabled) continue;
+                var require = !build.require ? false : craftManager.getResource(build.require);
+                if (!require || trigger <= require.value / require.maxValue) {
+                    if(typeof(build.stage) !== 'undefined' && build.stage !== game.bld.getBuildingExt(build.name || name).meta.stage) { 
+                      continue;
+                    }
+                    bList.push(new Object());
+                  	bList[i].id = name;
+                  	bList[i].label = build.label;
+                  	bList[i].name = build.name;
+                    bList[i].stage = build.stage;
+                  	i++;
+                }
+            }
+            
+            var tempPool = [];
+            for (res in game.resPool.resources) {
+              	tempPool.push(new Object());
+            		tempPool[res].name=game.resPool.resources[res].name;
+            }
+          
+            for (var res in tempPool) {tempPool[res].value = craftManager.getValueAvailable(tempPool[res].name, true);}
+            
+            
             // Using labeled for loop to break out of a nested loop
             // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/label
+            
             buildLoop:
             for (var name in builds) {
                 if (!builds[name].enabled) continue;
@@ -1054,6 +1083,12 @@ var run = function() {
             button.domNode.click(build);
             storeForSummary(name, 1, 'build');
 
+            
+          	/*button.controller.build(button.model, 10000);
+          	game.render()
+          	storeForSummary(name, amount, 'build');*/
+          
+            
             var label = build.meta.label ? build.meta.label : build.meta.stages[0].label;
             activity('Kittens have built a new ' + label, 'ks-build');
         },


### PR DESCRIPTION
I completely overhauled the automated building for the bonfire tab to be able to build more than a single building at a time. Now it instead it creates a temporary copy of the resource pool, and iterates through the array of possible buildings, subtracting the resource cost from the fake resource pool if possible to build an additional building of this type with the remaining resources and increasing the "to be built" number of this building by one, and removing the building from the array if no longer possible. This means that no building will be underrepresented by the system. All the usual conditions need to be met for a building to actually fall into the possible buildings array, enabled and trigger and actually being unlocked and etc.

The actual build manager has been modified somewhat too, it no longer clicks the button, instead calling a slightly modified version of the game's internal building function, changed to use KS's log system and also actually fixes a Kitten's Game bug where prices aren't correctly updated when building in bulk so shift-clicking to build-all will actually get you one extra building than you would be able to build by clicking individually. This has been fixed in the version used here by updating the price an extra time.

This new setup has seemingly no performance impact when KS is idling or only building small numbers of buildings, but is significantly quicker when buying in bulk, such as after a reset while paragon farming. Currently KS takes me like a half hour to an hour to build all possible buildings lagging the whole time, but with this it takes about 5 seconds to accomplish the same result. Because of this, I think a modification of this setup would work well for a trade revamp in the future, and I'll also eventually port it to all the other tab auto-builders.