### PR TITLE
Some Crafting/Trade Improvements and A Bulk Build Bugfix

### DIFF
--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -276,6 +276,11 @@ var run = function() {
                 // will be crafted into scaffolds. If instead limRat is 0.75, 625 of the beams will be crafted into scaffolds for a final result
                 // of 1125 beams-worth of scaffolds and 375 remaining beams.
                 // Currently, limRat is not modifiable through the UI, though if there is demand, perhaps this will be added in the future.
+                // Limited has a few other effects like balancing plates and steel while minimizing iron waste
+                
+                // TLDR: The purpose of the limited property is to proportionally distribute raw materials
+                // across all crafted resources without wasting raw materials.
+                
                 items: {
                     wood:       {require: 'catnip',      max: 0, limited: true, limRat: 0.5, enabled: true},
                     beam:       {require: 'wood',        max: 0, limited: true, limRat: 0.5, enabled: true},
@@ -1255,8 +1260,7 @@ var run = function() {
                     delta = this.getValueAvailable(i) / materials[i];
                 } else {
                     // Take the currently present amount of material to craft into account
-                    // Currently this determines the amount of resources that can be crafted such that the produced resources and their components
-                    // in storage both are "worth" the same number of base materials (as determined by price and craft ratio).
+                    // Currently this determines the amount of resources that can be crafted such that base materials are proportionally distributed across limited resources.
                     // This base material distribution is governed by limRat "limited ratio" which defaults to 0.5, corresponding to half of the possible components being further crafted.
                     // If this were another value, such as 0.75, then if you had 10000 beams and 0 scaffolds, 7500 of the beams would be crafted into scaffolds.
                     delta = limRat * ((this.getValueAvailable(i, true) + (materials[i] / (1 + ratio)) * this.getValueAvailable(res.name, true)) / materials[i]) - (this.getValueAvailable(res.name, true) / (1 + ratio));

--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -277,25 +277,25 @@ var run = function() {
                 // of 1125 beams-worth of scaffolds and 375 remaining beams.
                 // Currently, limRat is not modifiable through the UI, though if there is demand, perhaps this will be added in the future.
                 items: {
-                    wood:       {require: 'catnip',      max: 0, limited: false, limRat: 0.5, enabled: true},
-                    beam:       {require: 'wood',        max: 0, limited: false, limRat: 0.5, enabled: true},
-                    slab:       {require: 'minerals',    max: 0, limited: false, limRat: 0.5, enabled: true},
-                    steel:      {require: 'coal',        max: 0, limited: false, limRat: 0.5, enabled: true},
-                    plate:      {require: 'iron',        max: 0, limited: false, limRat: 0.5, enabled: true},
-                    alloy:      {require: 'titanium',    max: 0, limited: true,  limRat: 0.5, enabled: false},
-                    concrete:   {require: false,         max: 0, limited: true,  limRat: 0.5, enabled: false},
-                    gear:       {require: false,         max: 0, limited: true,  limRat: 0.5, enabled: false},
-                    scaffold:   {require: false,         max: 0, limited: true,  limRat: 0.5, enabled: false},
-                    ship:       {require: false,         max: 0, limited: true,  limRat: 0.5, enabled: false},
-                    tanker:     {require: false,         max: 0, limited: true,  limRat: 0.5, enabled: false},
-                    parchment:  {require: false,         max: 0, limited: false, limRat: 0.5, enabled: true},
-                    manuscript: {require: 'culture',     max: 0, limited: true,  limRat: 0.5, enabled: true},
-                    compendium: {require: 'science',     max: 0, limited: true,  limRat: 0.5, enabled: true},
-                    blueprint:  {require: 'science',     max: 0, limited: true,  limRat: 0.5, enabled: false},
-                    kerosene:   {require: 'oil',         max: 0, limited: false, limRat: 0.5, enabled: false},
-                    megalith:   {require: false,         max: 0, limited: true,  limRat: 0.5, enabled: false},
-                    eludium:    {require: 'unobtainium', max: 0, limited: false, limRat: 0.5, enabled: false},
-                    thorium:    {require: 'uranium',     max: 0, limited: false, limRat: 0.5, enabled: false}
+                    wood:       {require: 'catnip',      max: 0, limited: true, limRat: 0.5, enabled: true},
+                    beam:       {require: 'wood',        max: 0, limited: true, limRat: 0.5, enabled: true},
+                    slab:       {require: 'minerals',    max: 0, limited: true, limRat: 0.5, enabled: true},
+                    steel:      {require: 'coal',        max: 0, limited: true, limRat: 0.5, enabled: true},
+                    plate:      {require: 'iron',        max: 0, limited: true, limRat: 0.5, enabled: true},
+                    alloy:      {require: 'titanium',    max: 0, limited: true, limRat: 0.5, enabled: true},
+                    concrete:   {require: false,         max: 0, limited: true, limRat: 0.5, enabled: true},
+                    gear:       {require: false,         max: 0, limited: true, limRat: 0.5, enabled: true},
+                    scaffold:   {require: false,         max: 0, limited: true, limRat: 0.5, enabled: true},
+                    ship:       {require: false,         max: 0, limited: true, limRat: 0.5, enabled: true},
+                    tanker:     {require: false,         max: 0, limited: true, limRat: 0.5, enabled: true},
+                    parchment:  {require: false,         max: 0, limited: true, limRat: 0.5, enabled: true},
+                    manuscript: {require: 'culture',     max: 0, limited: true, limRat: 0.5, enabled: true},
+                    compendium: {require: 'science',     max: 0, limited: true, limRat: 0.5, enabled: true},
+                    blueprint:  {require: 'science',     max: 0, limited: true, limRat: 0.5, enabled: true},
+                    kerosene:   {require: 'oil',         max: 0, limited: true, limRat: 0.5, enabled: true},
+                    megalith:   {require: false,         max: 0, limited: true, limRat: 0.5, enabled: true},
+                    eludium:    {require: 'unobtainium', max: 0, limited: true, limRat: 0.5, enabled: true},
+                    thorium:    {require: 'uranium',     max: 0, limited: true, limRat: 0.5, enabled: true}
                 }
             },
             trade: {
@@ -343,8 +343,7 @@ var run = function() {
                 }
             },
             resources: {
-                furs:        {stock: 1000},
-                unobtainium: {consume: 1.0}
+                
             }
         }
     };
@@ -609,7 +608,7 @@ var run = function() {
                         pastureMeta.on = 0;
                         pastureMeta.val = 0;
                         pastureMeta.stage = 1;
-                        game.render();
+                        game.ui.render();
                         activity('Upgraded pastures to solar farms!', 'ks-upgrade');
                     }
                 }
@@ -621,7 +620,7 @@ var run = function() {
                         aqueductMeta.val = 0
                         aqueductMeta.stage = 1
                         aqueductMeta.calculateEffects(aqueductMeta, game)
-                        game.render()
+                        game.ui.render();
                         activity('Upgraded aqueducts to hydro plants!', 'ks-upgrade');
                     }
                 }
@@ -633,7 +632,7 @@ var run = function() {
                         libraryMeta.val = 0
                         libraryMeta.stage = 1
                         libraryMeta.calculateEffects(libraryMeta, game)
-                        game.render()
+                        game.ui.render();
                         activity('Upgraded libraries to data centers!', 'ks-upgrade');
                     }
                     
@@ -645,7 +644,7 @@ var run = function() {
                         amphitheatreMeta.on = 0
                         amphitheatreMeta.val = 0
                         amphitheatreMeta.stage = 1
-                        game.render()
+                        game.ui.render();
                         activity('Upgraded amphitheatres to broadcast towers!', 'ks-upgrade');
                     }
                 }
@@ -720,7 +719,7 @@ var run = function() {
                     buildManager.build(bList[entry].name || bList[entry].id, bList[entry].stage, bList[entry].count);
                 }
             }
-            game.render();
+            game.ui.render();
         },
         space: function () {
             var builds = options.auto.space.items;
@@ -750,17 +749,18 @@ var run = function() {
                 var current = !craft.max ? false : manager.getResource(name);
                 var require = !craft.require ? false : manager.getResource(craft.require);
                 var season = game.calendar.season;
-
+                var amount = 0;
                 // Ensure that we have reached our cap
                 if (current && current.value > craft.max) continue;
 
                 // Craft the resource if we meet the trigger requirement
                 if (!require || trigger <= require.value / require.maxValue) {
-                    var amount = manager.getLowestCraftAmount(name, craft.limited, craft.limRat);
-
-                    if (amount > 0) {
-                        manager.craft(name, amount);
-                    }
+                    amount = manager.getLowestCraftAmount(name, craft.limited, craft.limRat, true);
+                } else if (craft.limited) {
+                    amount = manager.getLowestCraftAmount(name, craft.limited, craft.limRat, false);
+                }
+                if (amount > 0) {
+                    manager.craft(name, amount);
                 }
             }
         },
@@ -1221,21 +1221,36 @@ var run = function() {
         getCraft: function (name) {
             return game.workshop.getCraft(this.getName(name));
         },
-        getLowestCraftAmount: function (name, limited, limRat) {
+        getLowestCraftAmount: function (name, limited, limRat, aboveTrigger) {
             var amount = Number.MAX_VALUE;
+            var plateMax = Number.MAX_VALUE;
             var materials = this.getMaterials(name);
             
             var craft = this.getCraft(name);
             var ratio = game.getResCraftRatio(craft);
-            
+            var trigger = options.auto.craft.trigger;
+          
             // Safeguard if materials for craft cannot be determined.
             if (!materials) return 0;
+            
+            if (name==='steel' && limited) {
+                var plateRatio=game.getResCraftRatio(this.getCraft('plate'));
+                if (this.getValueAvailable('plate')/this.getValueAvailable('steel') < ((plateRatio+1)/125)/((ratio+1)/100)) {
+                    return 0;
+                }
+            } else if (name==='plate' && limited) {
+                var steelRatio=game.getResCraftRatio(this.getCraft('steel'));
+                if (this.getValueAvailable('plate')/this.getValueAvailable('steel') > ((ratio+1)/125)/((steelRatio+1)/100)) {
+                    var ironInTime = ((this.getResource('coal').maxValue*trigger - this.getValue('coal'))/game.getResourcePerTick('coal', false))*game.getResourcePerTick('iron', false);
+                    plateMax = (this.getValueAvailable('iron') - Math.max(this.getResource('coal').maxValue*trigger - ironInTime,0))/125;
+                }
+            }
 
             var res = this.getResource(name);
 
             for (var i in materials) {
                 var delta = undefined;
-                if(this.getResource(i).maxValue > 0 || ! limited) {
+                if(! limited || (this.getResource(i).maxValue > 0 && aboveTrigger)) {
                     // If there is a storage limit, we can just use everything returned by getValueAvailable, since the regulation happens there
                     delta = this.getValueAvailable(i) / materials[i];
                 } else {
@@ -1244,10 +1259,10 @@ var run = function() {
                     // in storage both are "worth" the same number of base materials (as determined by price and craft ratio).
                     // This base material distribution is governed by limRat "limited ratio" which defaults to 0.5, corresponding to half of the possible components being further crafted.
                     // If this were another value, such as 0.75, then if you had 10000 beams and 0 scaffolds, 7500 of the beams would be crafted into scaffolds.
-                    delta = limRat * ((this.getValueAvailable(i) + (materials[i] / (1 + ratio)) * this.getValueAvailable(res.name)) / materials[i]) - (this.getValueAvailable(res.name) / (1 + ratio));
+                    delta = limRat * ((this.getValueAvailable(i, true) + (materials[i] / (1 + ratio)) * this.getValueAvailable(res.name, true)) / materials[i]) - (this.getValueAvailable(res.name, true) / (1 + ratio));
                 }
 
-                amount = Math.min(delta,amount);
+                amount = Math.min(delta,amount,plateMax);
             }
 
             // If we have a maximum value, ensure that we don't produce more than
@@ -1322,7 +1337,7 @@ var run = function() {
                 var res = options.auto.resources[name];
                 var consume = res && (res.consume != undefined) ? res.consume : options.consume;
 
-                value *= consume;
+                value -= Math.min(this.getResource(name).maxValue, value) * (1 - consume);
             }
 
             return value;

--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -1323,6 +1323,7 @@ var run = function() {
         getValueAvailable: function (name, all) {
             var value = this.getValue(name);
             var stock = this.getStock(name);
+            var trigger = options.auto.craft.trigger;
 
             if ('catnip' === name) {
                 var resPerTick = game.getResourcePerTick(name, false, {
@@ -1341,7 +1342,7 @@ var run = function() {
                 var res = options.auto.resources[name];
                 var consume = res && (res.consume != undefined) ? res.consume : options.consume;
 
-                value -= Math.min(this.getResource(name).maxValue, value) * (1 - consume);
+                value -= Math.min(this.getResource(name).maxValue * trigger, value) * (1 - consume);
             }
 
             return value;


### PR DESCRIPTION
This pull request is a collection of a handful of minor modifications to the crafting system to make limited crafting a bit more versatile.

Firstly, in the current version of KS, the limited toggle has no effect for resources made with only raw resources (such as slabs or plates). The reason for this is that the trigger and consumption rate took priority over limited crafting, so it would always wait until the trigger is reached before consuming the consumption rate in raw resources thus causing the limited toggle to have no effect. I've changed it so that limited crafting now takes priority over these, so that regardless of the storage cap, KS will for example turn 500 minerals into 250 minerals and 1 slab. Once the trigger value is reached or if limited is disabled for these resources, KS will behave as before.

This also had the effect of helping keep resources like alloy which have both uncapped and capped ingredients stay more proportional when limited is enabled.

Some special functionality was added for plates and steel as well, since they fall into the unique position of using the same uncapped resource, thus commonly causing the auto-production of one to block out the other. I've added a check for limited to keep these two proportional to each other while still crafting plates when iron would otherwise be wasted.

These changes together shift the goal of limited crafting from proportionally distributing raw materials down the crafting chain (eg, having beams and scaffolds such that both are worth the same amount of wood) to proportionally distributing raw materials across all limited crafted resources. KS default settings have been modified to reflect the new state of limited crafting.

Lastly, there is a small change to how consumption rate is handled so that multiple iterations of the crafting loop are no longer necessary when there are more raw materials than the storage limit (which can happen after resetting with chronospheres).

Also a bugfix for an issue where bulk crafting would slowly advance time while the game is paused.

Edit: Made some additional modifications to crafting and trade which optimize the crafting/trading loops so that they reach equilibrium after the first pass. Before, if you paused the game while autocrafting/trading, it would spam the log by repeatedly crafting/trading smaller and smaller values until it reached an equilibrium point, taking several minutes to accomplish this. Now both of these will reach equilibrium after one cycle. I've seen a noticeable improvement in performance for trading with this too.