### PR TITLE
Activity and Summary Updates, and Bulk Building

### DIFF
--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -1218,7 +1218,7 @@ var run = function() {
             // determine actual amount after crafting upgrades
             amount = (amount * (1 + ratio)).toFixed(2);
 
-            storeForSummary(ucfirst(craft.title), amount, 'craft');
+            storeForSummary(ucfirst(name), amount, 'craft');
             activity('Kittens have crafted ' + game.getDisplayValueExt(amount) + ' ' + ucfirst(name), 'ks-craft');
         },
         canCraft: function (name, amount) {


### PR DESCRIPTION
I've finally gone ahead and ported bulk building to the space, religion, and time menus. It was a nightmare, especially since the game is completely inconsistent about when a building is considered enabled and when it is considered visible, but I think I caught all the edge cases where stuff could be built early. Will merge in a bug-fix if any remain.

Besides that, this PR also contains some overhaul of the activity log and summary to make both of them more useful. Nothing to address the log spam yet but now everything outputs the correct numbers, uses the correct labels, and the summary actually outputs everything it is supposed to.

Lastly, there are some formatting fixes for parts of the code that used tabs instead of spaces.