### PR TITLE
Fixed manuscript crafting by pulling from the game's actual prices. 

### DIFF
--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -1959,8 +1959,9 @@ var run = function() {
             if (craft.unlocked && enabled) {
                 result = true;
 
-                for (var i in craft.prices) {
-                    var price = craft.prices[i];
+                var prices = game.workshop.getCraftPrice(craft); 
+                for (var i in prices) { 
+                    var price = prices[i]; 
                     var value = this.getValueAvailable(price.name);
 
                     if (value < price.val * amount) {


### PR DESCRIPTION
Fixes issue #289 and issue #286. Tested and seems to be functioning without any problems. Can set the trigger to any amount and resources will be crafted when available, including manuscripts.