### PR TITLE
Load KS automatically with alpha and beta versions of KG with Tampermonkey/Greasemonkey

### DIFF
--- a/kitten-scientists.user.js
+++ b/kitten-scientists.user.js
@@ -5,6 +5,8 @@
 // @include     *bloodrizer.ru/games/kittens/*
 // @include     file:///*kitten-game*
 // @include     *kittensgame.com/web/*
+// @include     *kittensgame.com/beta/*
+// @include     *kittensgame.com/alpha/*
 // @version     1.5.0
 // @grant       none
 // @copyright   2015, cameroncondry


### PR DESCRIPTION
This should automatically load Kitten Scientists on the alpha and beta versions of Kittens Game. Previously, you had to manually include the URL's in Tampermonkey/Greasemonkey to made KS load with the alpha and beta versions.